### PR TITLE
Add import String so that the example compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Make a file that uses the `runSuite` function:
 ```elm
 module Tests exposing (..)
 
+import String
 import ElmTest exposing (..)
 
 tests : Test


### PR DESCRIPTION
The example was missing an import.