### PR TITLE
Make Html runSuite display green/red for passing/failing tests

### DIFF
--- a/src/ElmTest/Runner/Html.elm
+++ b/src/ElmTest/Runner/Html.elm
@@ -1,4 +1,4 @@
-module ElmTest.Runner.Html exposing (runSuite) -- where
+module ElmTest.Runner.Html exposing (runSuite)
 
 {-| Run a test suite as an Html Program
 
@@ -13,30 +13,56 @@ import ElmTest.Test exposing (..)
 import ElmTest.Run as Run
 import ElmTest.Runner.String as String
 import Html.App as Html
+import Html.Attributes exposing (style)
 import Html
 
 
-{-| Run a test and print the output
+{-| Run a test and create an Html display of the results
 -}
-runDisplay : Test -> String
+runDisplay : Test -> Html.Html ()
 runDisplay tests =
-  case String.run tests of
-    ( summary, allPassed ) :: results ->
-      let
-        out =
-          summary ++ "\n\n" ++ (String.concat << List.intersperse "\n" << List.map fst <| results)
-      in
-        out
-    _ ->
-      Debug.crash ""
+    case String.run tests of
+        ( summary, allPassed ) :: results ->
+            Html.pre []
+                <| List.append [ Html.div [] [ Html.text summary ] ]
+                <| List.map displayTestResult results
+
+        _ ->
+            Debug.crash ""
 
 
 {-| Run the test suite and display as Html.
 -}
 runSuite : Test -> Program Never
-runSuite consoleTests =
-  Html.beginnerProgram
-    { model = runDisplay consoleTests
-    , view = (\x -> Html.pre [] [Html.text x])
-    , update = (\x y -> x)
-    }
+runSuite tests =
+    Html.beginnerProgram
+        { model = tests
+        , view = (\model -> runDisplay model)
+        , update = (\_ model -> model)
+        }
+
+
+displayTestResult : ( String, Run.Result ) -> Html.Html ()
+displayTestResult ( message, result ) =
+    let
+        passStyle =
+            style [ ( "background-color", "#0AE00A" ) ]
+
+        failStyle =
+            style [ ( "background-color", "#FF0000" ) ]
+
+        resultStyle =
+            case result of
+                Run.Pass _ ->
+                    passStyle
+
+                Run.Fail _ _ ->
+                    failStyle
+
+                Run.Report _ summary ->
+                    if List.isEmpty summary.failures then
+                        passStyle
+                    else
+                        failStyle
+    in
+        Html.div [ resultStyle ] [ Html.text message ]


### PR DESCRIPTION
The Html runner in the newest version of elm-test is a little difficult to use without any color to differentiate passing/failing specs:
<img width="578" alt="screen shot 2016-05-27 at 1 45 57 pm" src="https://cloud.githubusercontent.com/assets/2107646/15725280/c38cfd46-2810-11e6-98c2-c2d66d8ed9cc.png">
This adds back the red/green color:
<img width="591" alt="screen shot 2016-05-27 at 6 36 48 pm" src="https://cloud.githubusercontent.com/assets/2107646/15725288/d35a3dd8-2810-11e6-96b7-7db4dbe76ed0.png">
