### PR TITLE
Revise lots of docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: haskell
-install:
-  - npm install -g elm
-  - elm-package install -y
-before_script: 
-  - elm-make --yes --output test.js tests/Tests.elm
-script: node test.js

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-elm-test [![Build Status](https://travis-ci.org/elm-community/elm-test.png?branch=master)](https://travis-ci.org/elm-community/elm-test)
+# elm-test
 
-Write tests in Elm!
+Write unit and fuzz tests for your Elm code, in Elm.
 
-## Getting Started
+## Quick Start
 
-Let's start with some example code:
+Here are three example tests:
 
 ```elm
-test : Test
-test =
+suite : Test
+suite =
     describe "The String module"
         [ describe "String.reverse" -- Nest as many descriptions as you like.
             [ test "has no effect on a palindrome" <|
@@ -42,11 +42,11 @@ This code includes a few common things:
 * [`describe`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Test#test) to add a description string to a list of tests
 * [`test`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Test#test) to write a unit test
 * [`Expect`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Expect) to determine if a test should pass or fail
-* [`fuzz`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Test#fuzz) to run a test several times with randomly-generated inputs.
+* [`fuzz`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Test#fuzz) to run a function that produces a test several times with randomly-generated inputs
 
 Check out [a more complete example](https://github.com/elm-community/elm-test/tree/master/examples) or [a large real-world test suite](https://github.com/rtfeldman/elm-css/tree/master/test) for more.
 
-## Running tests locally
+### Running tests locally
 
 There are several ways you can run tests locally:
 
@@ -54,7 +54,7 @@ There are several ways you can run tests locally:
 * [from your browser](https://github.com/elm-community/elm-test-runner)
 * [using a custom runner](https://github.com/elm-community/elm-test/blob/master/example/LogRunnerExample.elm) of your own design
 
-## Running tests on CI
+### Running tests on CI
 
 Here are some examples of running tests on CI servers:
 

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -1,6 +1,6 @@
 module Expect exposing (Expectation, pass, fail, getFailure, equal, notEqual, atMost, lessThan, greaterThan, atLeast, true, false, onFail)
 
-{-| Determining whether tests pass or fail.
+{-| A library to create `Expectation`s, which describe a claim to be tested.
 
 ## Quick Reference
 
@@ -71,15 +71,13 @@ equal =
 
 {-| Passes if the arguments are not equal.
 
-    Expect.notEqual 11 (90 + 10)
-
     -- Passes because (11 /= 100) is True
+    90 + 10
+        |> Expect.notEqual 11
 
-Failures only show one value, because the reason for the failure was that
-both arguments were equal.
 
     -- Fails because (100 /= 100) is False
-    (90 + 10)
+    90 + 10
         |> Expect.notEqual 100
 
     {-

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -1,6 +1,6 @@
 module Test exposing (Test, FuzzOptions, describe, test, filter, concat, fuzz, fuzz2, fuzz3, fuzz4, fuzz5, fuzzWith)
 
-{-| Writing tests.
+{-| A module containing functions for creating and managing tests.
 
 @docs Test, test
 
@@ -99,7 +99,8 @@ test desc thunk =
     Internal.Labeled desc (Internal.Test (\_ _ -> [ thunk () ]))
 
 
-{-| Options [`fuzzWith`](#fuzzWith) accepts.
+{-| Options [`fuzzWith`](#fuzzWith) accepts. Currently there is only one but this
+API is designed so that it can accept more in the future.
 
 ### `runs`
 
@@ -166,9 +167,10 @@ fuzzWithHelp options test =
                 |> Internal.Batch
 
 
-{-| Run the given test several times, using a randomly-generated input from a
-`Fuzzer` each time. By default, runs the test 100 times with different inputs,
-but you can configure the run count using [`withRuns`](#withRuns).
+{-| Take a function that produces a test, and calls it several (usually 100) times, using a randomly-generated input
+from a [`Fuzzer`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Fuzz) each time. This allows you to
+test that a property that should always be true is indeed true under a wide variety of conditions. The function also
+takes a string describing the test.
 
 These are called "[fuzz tests](https://en.wikipedia.org/wiki/Fuzz_testing)" because of the randomness.
 You may find them elsewhere called [property-based tests](http://blog.jessitron.com/2013/04/property-based-testing-what-is-it.html),
@@ -182,8 +184,7 @@ You may find them elsewhere called [property-based tests](http://blog.jessitron.
 
     fuzz (list int) "List.length should always be positive" <|
         -- This anonymous function will be run 100 times, each time with a
-        -- randomly-generated fuzzList value. (You can configure the run count
-        -- using Fuzz.fuzzWith, or by giving your test runner a different default.)
+        -- randomly-generated fuzzList value.
         \fuzzList ->
             fuzzList
                 |> List.length


### PR DESCRIPTION
Mostly a bunch of docs improvements prior to the big release. Also
* Remove the travis badge from the README and `.travis.yml` since they weren't being used
* Don't rename `Random.Pcg` on import in the hopes that the full module name will be shown in the docs and prevent confusion with core/Random.

Still todo, I think the README needs to better explain the various runners and `elm-test` on npm.

cc @rtfeldman 