### PR TITLE
intRange and floatRange always test endpoints 10% of the time

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -146,7 +146,13 @@ inclusive. Shrunken values will also be within the range.
 -}
 intRange : Int -> Int -> Fuzzer Int
 intRange min max =
-    custom (Random.int min max)
+    custom
+        (Random.frequency
+            [ ( 8, Random.int min max )
+            , ( 1, Random.constant min )
+            , ( 1, Random.constant max )
+            ]
+        )
         (Shrink.keepIf (\i -> i >= min && i <= max) Shrink.int)
 
 
@@ -172,7 +178,13 @@ value, inclusive. Shrunken values will also be within the range.
 -}
 floatRange : Float -> Float -> Fuzzer Float
 floatRange min max =
-    custom (Random.float min max)
+    custom
+        (Random.frequency
+            [ ( 8, Random.float min max )
+            , ( 1, Random.constant min )
+            , ( 1, Random.constant max )
+            ]
+        )
         (Shrink.keepIf (\i -> i >= min && i <= max) Shrink.float)
 
 


### PR DESCRIPTION
The purpose of a fuzzer is to pick "interesting" values in hopes that they cause a test failure. For a range, this means the endpoints; thankfully fuzzer ranges are inclusive. For floats, the odds are that the endpoints will never be tested if you sample a range, so this makes sure we get them. This strategy is already used by `percentage`.

If you're fuzzing over just the range, then you don't need to produce the endpoints ten times; once is enough. But if you're fuzzer is used to build other fuzzers, you want some possibility of getting pairs of interesting values.

This is by no means an urgent fix but it'll be nice to have in the next release, whenever that is.

@rtfeldman Please make sure I'm not a "doofus" and then merge.