### PR TITLE
Remove links to missing examples from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This code includes a few common things:
 * [`Expect`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Expect) to determine if a test should pass or fail
 * [`fuzz`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Test#fuzz) to run a function that produces a test several times with randomly-generated inputs
 
-Check out [a more complete example](https://github.com/elm-community/elm-test/tree/master/examples) or [a large real-world test suite](https://github.com/rtfeldman/elm-css/tree/master/test) for more.
+Check out [a large real-world test suite](https://github.com/rtfeldman/elm-css/tree/master/test) for more.
 
 ### Running tests locally
 
@@ -52,7 +52,6 @@ There are several ways you can run tests locally:
 
 * [from your terminal](https://github.com/rtfeldman/node-test-runner) via `npm install -g elm-test`
 * [from your browser](https://github.com/rtfeldman/html-test-runner)
-* [using a custom runner](https://github.com/elm-community/elm-test/blob/master/example/LogRunnerExample.elm) of your own design
 
 Here's how set up and run your tests using the CLI test runner.
 


### PR DESCRIPTION
The examples in this repo were removed in 4d0d4a166288bf2eaeaf1fc2caf4def844f65b62 and 811fefc4fc0943d89589b74e0c094c5d9eb9f884. This PR removes links to those examples from the README.