### PR TITLE
Remove reference to opaque field from docs

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -62,7 +62,7 @@ Here is an example for a record:
             (Random.map2 Position (Random.int -100 100) (Random.int -100 100))
             (\{ x, y } -> Shrink.map Position (Shrink.int x) `Shrink.andMap` (Shrink.int y))
 
-Here is an example for a custom union type:
+Here is an example for a custom union type, assuming there is already a `genName : Generator String` defined:
 
     type Question
         = Name String
@@ -74,7 +74,7 @@ Here is an example for a custom union type:
             generator =
                 Random.bool `Random.andThen` (\b ->
                     if b then
-                        Random.map Name string.generator
+                        Random.map Name genName
                     else
                         Random.map Age (Random.int 0 120)
                  )


### PR DESCRIPTION
string.generator references indirectly internal structure of `Fuzzer` which might be confusing to readers.