### PR TITLE
Add collection expects

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -40,6 +40,10 @@ readmeExample =
                     "ABCDEFG"
                         |> String.reverse
                         |> Expect.equal "GFEDCBA"
+            , test "equal lists" <|
+                \() ->
+                    [ 1, 2, 3 ]
+                        |> Expect.equalLists [ 1, 2, 3 ]
             , test "equal dicts" <|
                 \() ->
                     (Dict.fromList [ ( 1, "one" ), ( 2, "two" ) ])

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -2,6 +2,7 @@ module Tests exposing (all)
 
 import Test exposing (..)
 import Fuzz exposing (..)
+import Dict
 import Set
 import String
 import Expect
@@ -39,6 +40,10 @@ readmeExample =
                     "ABCDEFG"
                         |> String.reverse
                         |> Expect.equal "GFEDCBA"
+            , test "equal dicts" <|
+                \() ->
+                    (Dict.fromList [ ( 1, "one" ), ( 2, "two" ) ])
+                        |> Expect.equalDicts (Dict.fromList [ ( 1, "one" ), ( 2, "two" ) ])
             , test "equal sets" <|
                 \() ->
                     (Set.fromList [ 1, 2, 3 ])

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -2,6 +2,7 @@ module Tests exposing (all)
 
 import Test exposing (..)
 import Fuzz exposing (..)
+import Set
 import String
 import Expect
 
@@ -38,6 +39,10 @@ readmeExample =
                     "ABCDEFG"
                         |> String.reverse
                         |> Expect.equal "GFEDCBA"
+            , test "equal sets" <|
+                \() ->
+                    (Set.fromList [ 1, 2, 3 ])
+                        |> Expect.equalSets (Set.fromList [ 1, 2, 3 ])
             , fuzz string "restores the original string if you run it again" <|
                 \randomlyGeneratedString ->
                     randomlyGeneratedString


### PR DESCRIPTION
Took a stab at implementing https://github.com/elm-community/elm-test/issues/31. They end up being pretty verbose, but the output should be easier to use than the standard `Expect.equal`. Let me know what you think.

There was also some mention in https://github.com/elm-community/elm-test/issues/41 of doing this kind of thing in 3rd party packages. If that's the preferred approach then I can close this and push it out as a separate package.