### PR TITLE
Use printf for formatting elm-make with sysconfcpus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - cd tests
   - npm install -g elm@$ELM_VERSION elm-test
   - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
-  - echo "#\!/bin/bash\\n\\necho \"Running elm-make with sysconfcpus -n 2\"\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\"" > $(npm config get prefix)/bin/elm-make
+  - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"' > $(npm config get prefix)/bin/elm-make
   - chmod +x $(npm config get prefix)/bin/elm-make
   - npm install
   - elm package install --yes


### PR DESCRIPTION
See: http://unix.stackexchange.com/questions/191694

The `echo "...\n\n..."` syntax seems to work fine on TravisCI and locally on OSX, but doesn't in some environments (like a new Ubuntu image) it stays as one line. Specifically this was causing `elm-make` to do nothing on CircleCI which was very frustrating to debug.

```
% echo "#\!/bin/bash\\n\\necho \"Running elm-make with sysconfcpus -n 2\"\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\""
#!/bin/bash

echo "Running elm-make with sysconfcpus -n 2"

/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"
% docker run --rm -t --interactive ubuntu
root@0028382c90e3:/# echo "#\!/bin/bash\\n\\necho \"Running elm-make with sysconfcpus -n 2\"\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\""
#\!/bin/bash\n\necho "Running elm-make with sysconfcpus -n 2"\n\n/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"
```

vs

```
% printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"'
#!/bin/bash

echo "Running elm-make with sysconfcpus -n 2"

$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"
% docker run --rm -t --interactive ubuntu
root@b84019a81012:/# printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"'
#!/bin/bash

echo "Running elm-make with sysconfcpus -n 2"

$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"
```