### PR TITLE
Update for 0.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ os:
 
 env:
   matrix:
-    - ELM_VERSION=0.17.1 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.17.1 TARGET_NODE_VERSION=4.0
+    - ELM_VERSION=0.18.0-beta TARGET_NODE_VERSION=node
+    - ELM_VERSION=0.18.0-beta TARGET_NODE_VERSION=4.0
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];

--- a/elm-package.json
+++ b/elm-package.json
@@ -16,7 +16,7 @@
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "mgold/elm-random-pcg": "4.0.1 <= v < 5.0.0"
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.0",
+    "version": "3.0.0",
     "summary": "Unit and Fuzz testing support with Console/Html/String outputs.",
     "repository": "https://github.com/elm-community/elm-test.git",
     "license": "BSD-3-Clause",

--- a/elm-package.json
+++ b/elm-package.json
@@ -13,10 +13,10 @@
         "Fuzz"
     ],
     "dependencies": {
-        "elm-community/elm-lazy-list": "1.3.0 <= v < 2.0.0",
-        "elm-community/shrink": "1.1.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "mgold/elm-random-pcg": "3.0.3 <= v < 4.0.0"
+        "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
+        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "mgold/elm-random-pcg": "4.0.0 <= v < 5.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -16,7 +16,7 @@
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "mgold/elm-random-pcg": "4.0.0 <= v < 5.0.0"
+        "mgold/elm-random-pcg": "4.0.1 <= v < 5.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -26,6 +26,7 @@ Instead of using a tuple, consider using `fuzzN`.
 
 -}
 
+import Tuple
 import Array exposing (Array)
 import Char
 import Util exposing (..)
@@ -763,7 +764,7 @@ frequency list =
         Err "You must provide at least one frequency pair."
     else if List.any (\( weight, _ ) -> weight < 0) list then
         Err "No frequency weights can be less than 0."
-    else if List.sum (List.map fst list) <= 0 then
+    else if List.sum (List.map Tuple.first list) <= 0 then
         Err "Frequency weights must sum to more than 0."
     else
         Ok <|

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -669,8 +669,8 @@ andMap =
 
 {-| Create a fuzzer based on the result of another fuzzer.
 -}
-andThen : (a -> Fuzzer b) -> Fuzzer a -> Fuzzer b
-andThen transform (Internal.Fuzzer baseFuzzer) =
+andThen : Fuzzer a -> (a -> Fuzzer b) -> Fuzzer b
+andThen (Internal.Fuzzer baseFuzzer) transform =
     Internal.Fuzzer
         (\noShrink ->
             case baseFuzzer noShrink of

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -61,7 +61,7 @@ Here is an example for a record:
     position =
         Fuzz.custom
             (Random.map2 Position (Random.int -100 100) (Random.int -100 100))
-            (\{ x, y } -> Shrink.map Position (Shrink.int x) `Shrink.andMap` (Shrink.int y))
+            (\{ x, y } -> Shrink.map Position (Shrink.int x) |> Shrink.andMap (Shrink.int y))
 
 Here is an example for a custom union type, assuming there is already a `genName : Generator String` defined:
 

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -661,10 +661,18 @@ map5 transform fuzzA fuzzB fuzzC fuzzD fuzzE =
 
 
 {-| Map over many fuzzers. This can act as mapN for N > 5.
+
+The argument order is meant to accomodate chaining:
+
+    map f aFuzzer
+        |> andMap anotherFuzzer
+        |> andMap aThirdFuzzer
+
+Note that shrinking may be better using mapN.
 -}
-andMap : Fuzzer (a -> b) -> Fuzzer a -> Fuzzer b
-andMap =
-    map2 (<|)
+andMap : Fuzzer a -> Fuzzer (a -> b) -> Fuzzer b
+andMap fuzzerVal fuzzerFunc =
+    map2 (<|) fuzzerFunc fuzzerVal
 
 
 {-| Create a fuzzer based on the result of another fuzzer.

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -677,8 +677,8 @@ andMap fuzzerVal fuzzerFunc =
 
 {-| Create a fuzzer based on the result of another fuzzer.
 -}
-andThen : Fuzzer a -> (a -> Fuzzer b) -> Fuzzer b
-andThen (Internal.Fuzzer baseFuzzer) transform =
+andThen : (a -> Fuzzer b) -> Fuzzer a -> Fuzzer b
+andThen transform (Internal.Fuzzer baseFuzzer) =
     Internal.Fuzzer
         (\noShrink ->
             case baseFuzzer noShrink of

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -72,7 +72,7 @@ Here is an example for a custom union type, assuming there is already a `genName
     question =
         let
             generator =
-                Random.bool `Random.andThen` (\b ->
+                Random.bool |> Random.andThen (\b ->
                     if b then
                         Random.map Name genName
                     else
@@ -260,7 +260,7 @@ string =
                 , ( 1, Random.int 11 50 )
                 , ( 1, Random.int 50 1000 )
                 ]
-                `Random.andThen` (lengthString charGenerator)
+                |> Random.andThen (lengthString charGenerator)
     in
         custom generator Shrink.string
 
@@ -355,12 +355,12 @@ list (Internal.Fuzzer baseFuzzer) =
                 case baseFuzzer noShrink of
                     Gen genVal ->
                         genLength
-                            |> (flip Random.andThen) (\i -> (Random.list i genVal))
+                            |> Random.andThen (\i -> (Random.list i genVal))
                             |> Gen
 
                     Shrink genTree ->
                         genLength
-                            |> (flip Random.andThen) (\i -> (Random.list i genTree))
+                            |> Random.andThen (\i -> (Random.list i genTree))
                             |> Random.map listShrinkHelp
                             |> Shrink
             )
@@ -394,7 +394,7 @@ listShrinkHelp listOfTrees =
             Lazy.List.numbers
                 |> Lazy.List.map (\i -> i - 1)
                 |> Lazy.List.take n
-                |> Lazy.List.flatMap
+                |> Lazy.List.andThen
                     (\i -> shrinkOne (List.take i listOfTrees) (List.drop i listOfTrees))
 
         shortened =
@@ -402,9 +402,9 @@ listShrinkHelp listOfTrees =
                 Lazy.List.iterate (\n -> n // 2) n
                     |> Lazy.List.takeWhile (\x -> x > 0)
              else
-                Lazy.List.fromList [1..n]
+                Lazy.List.fromList (List.range 1 n)
             )
-                |> Lazy.List.flatMap (\len -> shorter len listOfTrees False)
+                |> Lazy.List.andThen (\len -> shorter len listOfTrees False)
                 |> Lazy.List.map listShrinkHelp
 
         shorter windowSize aList recursing =
@@ -675,7 +675,7 @@ andThen transform (Internal.Fuzzer baseFuzzer) =
         (\noShrink ->
             case baseFuzzer noShrink of
                 Gen genVal ->
-                    Gen <| Random.andThen genVal (transform >> Internal.unpackGenVal)
+                    Gen <| Random.andThen (transform >> Internal.unpackGenVal) genVal
 
                 Shrink genTree ->
                     Shrink <| andThenRoseTrees transform genTree
@@ -684,23 +684,24 @@ andThen transform (Internal.Fuzzer baseFuzzer) =
 
 andThenRoseTrees : (a -> Fuzzer b) -> Generator (RoseTree a) -> Generator (RoseTree b)
 andThenRoseTrees transform genTree =
-    Random.andThen genTree
-        (\(Rose root branches) ->
-            let
-                -- genOtherChildren : Generator (LazyList (RoseTree b))
-                genOtherChildren =
-                    branches
-                        |> Lazy.List.map (\rt -> RoseTree.map (transform >> Internal.unpackGenTree) rt |> unwindRoseTree)
-                        |> unwindLazyList
-                        |> Random.map (Lazy.List.map RoseTree.flatten)
-            in
-                Random.map2
-                    (\(Rose trueRoot root'sChildren) otherChildren ->
-                        Rose trueRoot (Lazy.List.append root'sChildren otherChildren)
-                    )
-                    (Internal.unpackGenTree (transform root))
-                    genOtherChildren
-        )
+    genTree
+        |> Random.andThen
+            (\(Rose root branches) ->
+                let
+                    genOtherChildren : Generator (LazyList (RoseTree b))
+                    genOtherChildren =
+                        branches
+                            |> Lazy.List.map (\rt -> RoseTree.map (transform >> Internal.unpackGenTree) rt |> unwindRoseTree)
+                            |> unwindLazyList
+                            |> Random.map (Lazy.List.map RoseTree.flatten)
+                in
+                    Random.map2
+                        (\(Rose trueRoot rootsChildren) otherChildren ->
+                            Rose trueRoot (Lazy.List.append rootsChildren otherChildren)
+                        )
+                        (Internal.unpackGenTree (transform root))
+                        genOtherChildren
+            )
 
 
 unwindRoseTree : RoseTree (Generator a) -> Generator (RoseTree a)

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -100,7 +100,7 @@ fuzzTest fuzzer desc getExpectation =
 
 
 shrinkAndAdd : RoseTree a -> (a -> Expectation) -> Expectation -> Dict String Expectation -> Dict String Expectation
-shrinkAndAdd rootTree getExpectation root'sExpectation dict =
+shrinkAndAdd rootTree getExpectation rootsExpectation dict =
     -- Knowing that the root already failed, adds the shrunken failure to the dictionary
     let
         shrink oldExpectation (Rose root branches) =
@@ -118,7 +118,7 @@ shrinkAndAdd rootTree getExpectation root'sExpectation dict =
                     ( root, oldExpectation )
 
         ( result, finalExpectation ) =
-            shrink root'sExpectation rootTree
+            shrink rootsExpectation rootTree
     in
         Dict.insert (toString result) finalExpectation dict
 

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -16,6 +16,7 @@ own tests, you should use these runners; see the `README` for more information.
 @docs formatLabels
 -}
 
+import Tuple
 import Test exposing (Test)
 import Test.Internal as Internal
 import Expect exposing (Expectation)
@@ -75,7 +76,7 @@ fromTest runs seed test =
             Internal.Batch subTests ->
                 subTests
                     |> List.foldl (distributeSeeds runs) ( seed, [] )
-                    |> snd
+                    |> Tuple.second
                     |> Batch
 
 

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -11,19 +11,22 @@ import String
 rangeLengthList : Int -> Int -> Generator a -> Generator (List a)
 rangeLengthList minLength maxLength generator =
     (int minLength maxLength)
-        `andThen` (\len -> list len generator)
+        |> andThen (\len -> list len generator)
 
 
 rangeLengthArray : Int -> Int -> Generator a -> Generator (Array a)
 rangeLengthArray minLength maxLength generator =
-    rangeLengthList minLength maxLength generator |> map Array.fromList
+    rangeLengthList minLength maxLength generator
+        |> map Array.fromList
 
 
 rangeLengthString : Int -> Int -> Generator Char -> Generator String
 rangeLengthString minLength maxLength charGenerator =
-    (int minLength maxLength) `andThen` (lengthString charGenerator)
+    (int minLength maxLength)
+        |> andThen (lengthString charGenerator)
 
 
 lengthString : Generator Char -> Int -> Generator String
 lengthString charGenerator stringLength =
-    map String.fromList (list stringLength charGenerator)
+    list stringLength charGenerator
+        |> map String.fromList

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -8,14 +8,13 @@ Note that this always uses an initial seed of 902101337, since it can't do effec
 -}
 
 import Runner.Log
-import Html.App
 import Html
 import Tests
 
 
-main : Program Never
+main : Program Never () msg
 main =
-    Html.App.beginnerProgram
+    Html.beginnerProgram
         { model = ()
         , update = \_ _ -> ()
         , view = \() -> Html.text "Check the console for useful output!"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,5 +1,6 @@
 module Tests exposing (all)
 
+import Tuple
 import Test exposing (..)
 import Test.Expectation exposing (Expectation(..))
 import Test.Internal as TI
@@ -93,6 +94,10 @@ fuzzerTests =
                     testStringLengthIsPreserved [ a, b, c, d, e ]
             ]
         , fuzz
+            (intRange 1 6)
+            "intRange"
+            (Expect.greaterThan 0)
+        , fuzz
             (frequencyOrCrash [ ( 1, intRange 1 6 ), ( 1, intRange 1 20 ) ])
             "Fuzz.frequency(OrCrash)"
             (Expect.greaterThan 0)
@@ -124,10 +129,10 @@ fuzzerTests =
                                 )
 
                         valNoShrink =
-                            aFuzzer |> Fuzz.Internal.unpackGenVal |> step |> fst
+                            aFuzzer |> Fuzz.Internal.unpackGenVal |> step |> Tuple.first
 
                         valWithShrink =
-                            aFuzzer |> Fuzz.Internal.unpackGenTree |> step |> fst |> RoseTree.root
+                            aFuzzer |> Fuzz.Internal.unpackGenTree |> step |> Tuple.first |> RoseTree.root
                     in
                         Expect.equal valNoShrink valWithShrink
             ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,11 +9,11 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-lazy-list": "1.3.0 <= v < 2.0.0",
-        "elm-community/shrink": "1.1.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0",
-        "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0"
+        "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
+        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.1 <= v < 5.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -13,7 +13,7 @@
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "mgold/elm-random-pcg": "4.0.1 <= v < 5.0.0"
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Waiting in the wings.

This will be a major version bump thanks to `andThen` arg order. I've also swapped the order for `andMap` so it works better with `|>` (see added docs). This is less standardized, but with `Task.andMap` gone from core, I think third-party libs are free to do as they choose. `json-extra` is going this way, and I did it for the `lazy-list` and `shrink` libs I maintain (that `elm-test` depends on), so I think it should be fine.

@rtfeldman, thoughts?
