### PR TITLE
Test failure representation improvements

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -543,14 +543,16 @@ getFailureMessage { given, description, reason } =
             verticalBar description e a
 
         Test.Expectation.ListDiff e a ( i, itemE, itemA ) ->
-            verticalBar description e a
-                ++ "\n\nThe first diff is at index index "
-                ++ toString i
-                ++ ": it was `"
-                ++ itemA
-                ++ "`, but `"
-                ++ itemE
-                ++ "` was expected."
+            String.join ""
+                [ verticalBar description e a
+                , "\n\nThe first diff is at index index "
+                , toString i
+                , ": it was `"
+                , itemA
+                , "`, but `"
+                , itemE
+                , "` was expected."
+                ]
 
         Test.Expectation.CollectionDiff { expected, actual, extra, missing } ->
             let
@@ -568,10 +570,12 @@ getFailureMessage { given, description, reason } =
                         "\nThese keys are missing: "
                             ++ (missing |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
             in
-                verticalBar description expected actual
-                    ++ "\n"
-                    ++ extraStr
-                    ++ missingStr
+                String.join ""
+                    [ verticalBar description expected actual
+                    , "\n"
+                    , extraStr
+                    , missingStr
+                    ]
 
 
 {-| If the given expectation fails, replace its failure message with a custom one.
@@ -667,6 +671,8 @@ reportCollectionFailure comparison expected actual missingKeys extraKeys =
         }
 
 
+{-| String arg is label, e.g. "Expect.equal".
+-}
 equateWith : String -> (a -> b -> Bool) -> b -> a -> Expectation
 equateWith =
     testWith Test.Expectation.Equals
@@ -678,8 +684,8 @@ compareWith =
 
 
 testWith : (String -> String -> Test.Expectation.Reason) -> String -> (a -> b -> Bool) -> b -> a -> Expectation
-testWith makeReason label compare expected actual =
-    if compare actual expected then
+testWith makeReason label runTest expected actual =
+    if runTest actual expected then
         pass
     else
         Test.Expectation.Fail

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -591,26 +591,26 @@ allHelp list query =
 
 reportFailure : String -> String -> String -> Expectation
 reportFailure comparison expected actual =
-    Test.Expectation.Fail
-        { given = ""
-        , description = comparison
-        , reason = Test.Expectation.Comparison (toString expected) (toString actual)
-        }
+    { given = ""
+    , description = comparison
+    , reason = Test.Expectation.Comparison (toString expected) (toString actual)
+    }
+        |> Test.Expectation.Fail
 
 
 reportCollectionFailure : String -> a -> b -> List c -> List d -> Expectation
 reportCollectionFailure comparison expected actual missingKeys extraKeys =
-    Test.Expectation.Fail
-        { given = ""
-        , description = comparison
-        , reason =
-            Test.Expectation.CollectionDiff
-                { expected = toString expected
-                , actual = toString actual
-                , extra = List.map toString extraKeys
-                , missing = List.map toString missingKeys
-                }
+    { given = ""
+    , description = comparison
+    , reason =
+        { expected = toString expected
+        , actual = toString actual
+        , extra = List.map toString extraKeys
+        , missing = List.map toString missingKeys
         }
+            |> Test.Expectation.CollectionDiff
+    }
+        |> Test.Expectation.Fail
 
 
 {-| String arg is label, e.g. "Expect.equal".
@@ -630,8 +630,8 @@ testWith makeReason label runTest expected actual =
     if runTest actual expected then
         pass
     else
-        Test.Expectation.Fail
-            { given = ""
-            , description = label
-            , reason = makeReason (toString expected) (toString actual)
-            }
+        { given = ""
+        , description = label
+        , reason = makeReason (toString expected) (toString actual)
+        }
+            |> Test.Expectation.Fail

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -490,8 +490,8 @@ pass =
                     Expect.fail err
 -}
 fail : String -> Expectation
-fail =
-    Test.Expectation.Fail ""
+fail str =
+    Test.Expectation.Fail { given = "", description = str, reason = Test.Expectation.Custom }
 
 
 {-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
@@ -515,8 +515,8 @@ getFailure expectation =
         Test.Expectation.Pass ->
             Nothing
 
-        Test.Expectation.Fail given message ->
-            Just { given = given, message = message }
+        Test.Expectation.Fail { given, description } ->
+            Just { given = given, message = description }
 
 
 {-| If the given expectation fails, replace its failure message with a custom one.
@@ -531,8 +531,8 @@ onFail str expectation =
         Test.Expectation.Pass ->
             expectation
 
-        Test.Expectation.Fail given _ ->
-            Test.Expectation.Fail given str
+        Test.Expectation.Fail failure ->
+            Test.Expectation.Fail { failure | description = str, reason = Test.Expectation.Custom }
 
 
 reportFailure : String -> String -> String -> String

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -515,51 +515,8 @@ getFailure expectation =
         Test.Expectation.Pass ->
             Nothing
 
-        Test.Expectation.Fail { given, description, reason } ->
-            let
-                message =
-                    case reason of
-                        Test.Expectation.Custom ->
-                            description
-
-                        Test.Expectation.Equals e a ->
-                            verticalBar description e a
-
-                        Test.Expectation.Comparison e a ->
-                            verticalBar description e a
-
-                        Test.Expectation.ListDiff e a ( i, itemE, itemA ) ->
-                            verticalBar description e a
-                                ++ "\n\nThe first diff is at index index "
-                                ++ toString i
-                                ++ ": it was `"
-                                ++ itemA
-                                ++ "`, but `"
-                                ++ itemE
-                                ++ "` was expected."
-
-                        Test.Expectation.CollectionDiff { expected, actual, extra, missing } ->
-                            let
-                                extraStr =
-                                    if List.isEmpty extra then
-                                        ""
-                                    else
-                                        "\nThese keys are extra: "
-                                            ++ (extra |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
-
-                                missingStr =
-                                    if List.isEmpty missing then
-                                        ""
-                                    else
-                                        "\nThese keys are missing: "
-                                            ++ (missing |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
-                            in
-                                verticalBar description expected actual
-                                    ++ "\n"
-                                    ++ extraStr
-                                    ++ missingStr
-            in
-                Just { given = given, message = message }
+        Test.Expectation.Fail record ->
+            Just { given = record.given, message = getFailureMessage record }
 
 
 verticalBar : String -> String -> String -> String
@@ -571,6 +528,50 @@ verticalBar comparison expected actual =
     , expected
     ]
         |> String.join "\n"
+
+
+getFailureMessage : { given : String, description : String, reason : Test.Expectation.Reason } -> String
+getFailureMessage { given, description, reason } =
+    case reason of
+        Test.Expectation.Custom ->
+            description
+
+        Test.Expectation.Equals e a ->
+            verticalBar description e a
+
+        Test.Expectation.Comparison e a ->
+            verticalBar description e a
+
+        Test.Expectation.ListDiff e a ( i, itemE, itemA ) ->
+            verticalBar description e a
+                ++ "\n\nThe first diff is at index index "
+                ++ toString i
+                ++ ": it was `"
+                ++ itemA
+                ++ "`, but `"
+                ++ itemE
+                ++ "` was expected."
+
+        Test.Expectation.CollectionDiff { expected, actual, extra, missing } ->
+            let
+                extraStr =
+                    if List.isEmpty extra then
+                        ""
+                    else
+                        "\nThese keys are extra: "
+                            ++ (extra |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
+
+                missingStr =
+                    if List.isEmpty missing then
+                        ""
+                    else
+                        "\nThese keys are missing: "
+                            ++ (missing |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
+            in
+                verticalBar description expected actual
+                    ++ "\n"
+                    ++ extraStr
+                    ++ missingStr
 
 
 {-| If the given expectation fails, replace its failure message with a custom one.

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -54,6 +54,7 @@ module Expect
 -}
 
 import Test.Expectation
+import Test.Message exposing (failureMessage)
 import Dict exposing (Dict)
 import Set exposing (Set)
 import String
@@ -516,66 +517,7 @@ getFailure expectation =
             Nothing
 
         Test.Expectation.Fail record ->
-            Just { given = record.given, message = getFailureMessage record }
-
-
-verticalBar : String -> String -> String -> String
-verticalBar comparison expected actual =
-    [ actual
-    , "╷"
-    , "│ " ++ comparison
-    , "╵"
-    , expected
-    ]
-        |> String.join "\n"
-
-
-getFailureMessage : { given : String, description : String, reason : Test.Expectation.Reason } -> String
-getFailureMessage { given, description, reason } =
-    case reason of
-        Test.Expectation.Custom ->
-            description
-
-        Test.Expectation.Equals e a ->
-            verticalBar description e a
-
-        Test.Expectation.Comparison e a ->
-            verticalBar description e a
-
-        Test.Expectation.ListDiff e a ( i, itemE, itemA ) ->
-            String.join ""
-                [ verticalBar description e a
-                , "\n\nThe first diff is at index index "
-                , toString i
-                , ": it was `"
-                , itemA
-                , "`, but `"
-                , itemE
-                , "` was expected."
-                ]
-
-        Test.Expectation.CollectionDiff { expected, actual, extra, missing } ->
-            let
-                extraStr =
-                    if List.isEmpty extra then
-                        ""
-                    else
-                        "\nThese keys are extra: "
-                            ++ (extra |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
-
-                missingStr =
-                    if List.isEmpty missing then
-                        ""
-                    else
-                        "\nThese keys are missing: "
-                            ++ (missing |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
-            in
-                String.join ""
-                    [ verticalBar description expected actual
-                    , "\n"
-                    , extraStr
-                    , missingStr
-                    ]
+            Just { given = record.given, message = failureMessage record }
 
 
 {-| If the given expectation fails, replace its failure message with a custom one.

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -1,16 +1,26 @@
-module Test.Expectation exposing (Expectation(..), withGiven)
+module Test.Expectation exposing (Expectation(..), Reason(..), withGiven)
 
 
 type Expectation
     = Pass
-    | Fail String String
+    | Fail { given : String, description : String, reason : Reason }
+
+
+
+-- TODO: given : Maybe String
+
+
+type Reason
+    = Custom
+    | Equals String String
+    | Comparison String String
 
 
 withGiven : String -> Expectation -> Expectation
-withGiven given outcome =
-    case outcome of
-        Fail _ message ->
-            Fail given message
+withGiven newGiven expectation =
+    case expectation of
+        Fail failure ->
+            Fail { failure | given = newGiven }
 
         Pass ->
-            outcome
+            expectation

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -14,6 +14,21 @@ type Reason
     = Custom
     | Equals String String
     | Comparison String String
+      -- Expected, actual, (index of problem, expected element, actual element)
+    | ListDiff String String ( Int, String, String )
+      {- I don't think we need to show the diff twice with + and - reversed. Just show it after the main vertical bar.
+         "Extra" and "missing" are relative to the actual value.
+      -}
+    | CollectionDiff
+        { expected : String
+        , actual : String
+        , extra : List String
+        , missing : List String
+        }
+
+
+
+--type alias CollectionDiff = {
 
 
 withGiven : String -> Expectation -> Expectation

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -27,10 +27,8 @@ type Reason
         }
 
 
-
---type alias CollectionDiff = {
-
-
+{-| Set the given (fuzz test input) of an expectation.
+-}
 withGiven : String -> Expectation -> Expectation
 withGiven newGiven expectation =
     case expectation of

--- a/src/Test/Message.elm
+++ b/src/Test/Message.elm
@@ -1,0 +1,63 @@
+module Test.Message exposing (failureMessage)
+
+import String
+import Test.Expectation exposing (Reason(..))
+
+
+verticalBar : String -> String -> String -> String
+verticalBar comparison expected actual =
+    [ actual
+    , "╷"
+    , "│ " ++ comparison
+    , "╵"
+    , expected
+    ]
+        |> String.join "\n"
+
+
+failureMessage : { given : String, description : String, reason : Reason } -> String
+failureMessage { given, description, reason } =
+    case reason of
+        Custom ->
+            description
+
+        Equals e a ->
+            verticalBar description e a
+
+        Comparison e a ->
+            verticalBar description e a
+
+        ListDiff e a ( i, itemE, itemA ) ->
+            String.join ""
+                [ verticalBar description e a
+                , "\n\nThe first diff is at index index "
+                , toString i
+                , ": it was `"
+                , itemA
+                , "`, but `"
+                , itemE
+                , "` was expected."
+                ]
+
+        CollectionDiff { expected, actual, extra, missing } ->
+            let
+                extraStr =
+                    if List.isEmpty extra then
+                        ""
+                    else
+                        "\nThese keys are extra: "
+                            ++ (extra |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
+
+                missingStr =
+                    if List.isEmpty missing then
+                        ""
+                    else
+                        "\nThese keys are missing: "
+                            ++ (missing |> String.join ", " |> \d -> "[ " ++ d ++ " ]")
+            in
+                String.join ""
+                    [ verticalBar description expected actual
+                    , "\n"
+                    , extraStr
+                    , missingStr
+                    ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -153,10 +153,10 @@ testShrinking test =
                                 Pass ->
                                     Just "Expected this test to fail, but it passed!"
 
-                                Fail given outcome ->
+                                Fail { given, description } ->
                                     let
                                         acceptable =
-                                            String.split "|" outcome
+                                            String.split "|" description
                                     in
                                         if List.member given acceptable then
                                             Nothing


### PR DESCRIPTION
This patch changes the representation of a failure to track different pieces of data based on the type of failure. The goal is to obtain better json reports (which should never contain the vertical bar), and to be able to do diff highlighting (which you do for equality failures but not comparison [e.g. less than] failures).

@rtfeldman and I worked on this at the hack night.

I believe that this should be a patch release and does not regress error reporting output. The one thing left to do is update the docs for how each failure will look when reported. I suspect there will be some back-and-forth on that -- treat this as a first draft -- and we can update the docs when it's finalized.