### PR TITLE
Implement Test.todo

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -3,7 +3,6 @@ module Expect
         ( Expectation
         , pass
         , fail
-        , getFailure
         , equal
         , notEqual
         , atMost
@@ -51,11 +50,10 @@ module Expect
 
 ## Customizing
 
-@docs pass, fail, onFail, getFailure
+@docs pass, fail, onFail
 -}
 
 import Test.Expectation
-import Test.Message exposing (failureMessage)
 import Dict exposing (Dict)
 import Set exposing (Set)
 import String
@@ -533,34 +531,6 @@ pass =
 fail : String -> Expectation
 fail str =
     Test.Expectation.fail { description = str, reason = Test.Expectation.Custom }
-
-
-{-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
-
-If it is a [`fail`](#fail), return a record containing the failure message,
-along with the given inputs if it was a fuzz test. (If no inputs were involved,
-the record's `given` field will be `""`).
-
-For example, if a fuzz test generates random integers, this might return
-`{ message = "it was supposed to be positive", given = "-1" }`
-
-    getFailure (Expect.fail "this failed")
-    -- Just { message = "this failed", given = "" }
-
-    getFailure (Expect.pass)
-    -- Nothing
--}
-getFailure : Expectation -> Maybe { given : String, message : String }
-getFailure expectation =
-    case expectation of
-        Test.Expectation.Pass ->
-            Nothing
-
-        Test.Expectation.Fail record ->
-            Just
-                { given = record.given |> Maybe.withDefault ""
-                , message = failureMessage record
-                }
 
 
 {-| If the given expectation fails, replace its failure message with a custom one.

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -1,4 +1,4 @@
-module Test exposing (Test, FuzzOptions, describe, test, filter, concat, fuzz, fuzz2, fuzz3, fuzz4, fuzz5, fuzzWith)
+module Test exposing (Test, FuzzOptions, describe, test, filter, concat, todo, fuzz, fuzz2, fuzz3, fuzz4, fuzz5, fuzzWith)
 
 {-| A module containing functions for creating and managing tests.
 
@@ -6,7 +6,7 @@ module Test exposing (Test, FuzzOptions, describe, test, filter, concat, fuzz, f
 
 ## Organizing Tests
 
-@docs describe, concat, filter
+@docs describe, concat, filter, todo
 
 ## Fuzz Testing
 
@@ -14,6 +14,7 @@ module Test exposing (Test, FuzzOptions, describe, test, filter, concat, fuzz, f
 -}
 
 import Test.Internal as Internal
+import Test.Expectation
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer)
 
@@ -97,6 +98,38 @@ describe desc =
 test : String -> (() -> Expectation) -> Test
 test desc thunk =
     Internal.Labeled desc (Internal.Test (\_ _ -> [ thunk () ]))
+
+
+{-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests
+always fail, but test runners will only include them in their output if there
+are no other failures.
+
+These tests aren't meant to be committed to version control. Instead, use them
+when you're brainstorming lots of tests you'd like to write, but you can't
+implement them all at once. When you replace `todo` with a real test, you'll be
+able to see if it fails without clutter from tests still not implemented. But,
+unlike leaving yourself comments, you'll be prompted to implement these tests
+because your suite will fail.
+
+    describe "a new thing"
+        [ todo "does what is expected in the common case"
+        , todo "correctly handles an edge case I just thought of"
+        ]
+
+This functionality is similar to "pending" tests in other frameworks, except
+that a TODO test is considered failing but a pending test often is not.
+-}
+todo : String -> Test
+todo desc =
+    Internal.Test
+        (\_ _ ->
+            [ Test.Expectation.Fail
+                { given = Nothing
+                , description = desc
+                , reason = Test.Expectation.TODO
+                }
+            ]
+        )
 
 
 {-| Options [`fuzzWith`](#fuzzWith) accepts. Currently there is only one but this

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -21,6 +21,7 @@ type Reason
         , extra : List String
         , missing : List String
         }
+    | TODO
 
 
 {-| Create a failure without specifying the given.

--- a/src/Test/Message.elm
+++ b/src/Test/Message.elm
@@ -27,6 +27,9 @@ failureMessage { given, description, reason } =
         Comparison e a ->
             verticalBar description e a
 
+        TODO ->
+            "TODO: " ++ description
+
         ListDiff e a ( i, itemE, itemA ) ->
             String.join ""
                 [ verticalBar description e a

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -45,17 +45,19 @@ toOutputHelp labels runner summary =
 
 fromExpectation : Expectation -> Summary -> Summary
 fromExpectation expectation summary =
-    case Expect.getFailure expectation of
+    case Test.Runner.getFailure expectation of
         Nothing ->
             { summary | passed = summary.passed + 1 }
 
         Just { given, message } ->
             let
                 prefix =
-                    if String.isEmpty given then
-                        ""
-                    else
-                        "Given " ++ given ++ "\n\n"
+                    case given of
+                        Nothing ->
+                            ""
+
+                        Just g ->
+                            "Given " ++ g ++ "\n\n"
 
                 newOutput =
                     "\n\n" ++ (prefix ++ indentLines message) ++ "\n"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -20,7 +20,7 @@ import Helpers exposing (..)
 all : Test
 all =
     Test.concat
-        [ readmeExample, regressions, expectationTests, fuzzerTests ]
+        [ readmeExample, regressions, todoTests, expectationTests, fuzzerTests ]
 
 
 readmeExample : Test
@@ -84,6 +84,24 @@ expectationTests =
                         Ok 12 |> Expect.err
             ]
           -- , describe "Expect.somethingElse" [ ... ]
+        ]
+
+
+todoTests : Test
+todoTests =
+    describe "Test.todo"
+        [ expectToFail <| todo "a TODO test fails"
+        , test "Passes are not TODO" <|
+            \_ ->
+                Expect.pass |> Test.Runner.isTodo |> Expect.false "was true"
+        , test "Simple failures are not TODO" <|
+            \_ ->
+                Expect.fail "reason" |> Test.Runner.isTodo |> Expect.false "was true"
+        , test "Failures with TODO reason are TODO" <|
+            \_ ->
+                Test.Expectation.fail { description = "", reason = Test.Expectation.TODO }
+                    |> Test.Runner.isTodo
+                    |> Expect.true "was false"
         ]
 
 


### PR DESCRIPTION
Related to #94, but first: how do we implement the "don't show these failures in the output" behavior?

* Filter them in `Test.Runner.run`. This ensures that the node and HTML runners are consistent, and that this PR can be merged without dependencies on other repos.
* Filter them in the runners. This seems like the more "correct" thing to do because it allows, for example, the node runner to take a flag to show even (or only) the TODO test failures. (`--todo=(show|hide|only), default: hide`)

Either way, we need to resolve this before merging, or at least releasing.

@rtfeldman I'd be happy to take a crack at adding support to the node runner, just let me know.