### PR TITLE
Refactor given to be a Maybe String

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -320,11 +320,10 @@ err : Result a b -> Expectation
 err result =
     case result of
         Ok _ ->
-            { given = ""
-            , description = "Expect.err"
+            { description = "Expect.err"
             , reason = Test.Expectation.Comparison "Err _" (toString result)
             }
-                |> Test.Expectation.Fail
+                |> Test.Expectation.fail
 
         Err _ ->
             pass
@@ -382,9 +381,8 @@ equalLists expected actual =
                                         (toString actual)
                                         ( index, toString e, toString a )
                             in
-                                Test.Expectation.Fail
-                                    { given = ""
-                                    , description = "Expect.equalLists"
+                                Test.Expectation.fail
+                                    { description = "Expect.equalLists"
                                     , reason = reason
                                     }
                         )
@@ -534,7 +532,7 @@ pass =
 -}
 fail : String -> Expectation
 fail str =
-    Test.Expectation.Fail { given = "", description = str, reason = Test.Expectation.Custom }
+    Test.Expectation.fail { description = str, reason = Test.Expectation.Custom }
 
 
 {-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
@@ -559,7 +557,10 @@ getFailure expectation =
             Nothing
 
         Test.Expectation.Fail record ->
-            Just { given = record.given, message = failureMessage record }
+            Just
+                { given = record.given |> Maybe.withDefault ""
+                , message = failureMessage record
+                }
 
 
 {-| If the given expectation fails, replace its failure message with a custom one.
@@ -633,17 +634,15 @@ allHelp list query =
 
 reportFailure : String -> String -> String -> Expectation
 reportFailure comparison expected actual =
-    { given = ""
-    , description = comparison
+    { description = comparison
     , reason = Test.Expectation.Comparison (toString expected) (toString actual)
     }
-        |> Test.Expectation.Fail
+        |> Test.Expectation.fail
 
 
 reportCollectionFailure : String -> a -> b -> List c -> List d -> Expectation
 reportCollectionFailure comparison expected actual missingKeys extraKeys =
-    { given = ""
-    , description = comparison
+    { description = comparison
     , reason =
         { expected = toString expected
         , actual = toString actual
@@ -652,7 +651,7 @@ reportCollectionFailure comparison expected actual missingKeys extraKeys =
         }
             |> Test.Expectation.CollectionDiff
     }
-        |> Test.Expectation.Fail
+        |> Test.Expectation.fail
 
 
 {-| String arg is label, e.g. "Expect.equal".
@@ -672,8 +671,7 @@ testWith makeReason label runTest expected actual =
     if runTest actual expected then
         pass
     else
-        { given = ""
-        , description = label
+        { description = label
         , reason = makeReason (toString expected) (toString actual)
         }
-            |> Test.Expectation.Fail
+            |> Test.Expectation.fail

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -1,13 +1,9 @@
-module Test.Expectation exposing (Expectation(..), Reason(..), withGiven)
+module Test.Expectation exposing (Expectation(..), Reason(..), fail, withGiven)
 
 
 type Expectation
     = Pass
-    | Fail { given : String, description : String, reason : Reason }
-
-
-
--- TODO: given : Maybe String
+    | Fail { given : Maybe String, description : String, reason : Reason }
 
 
 type Reason
@@ -27,13 +23,20 @@ type Reason
         }
 
 
+{-| Create a failure without specifying the given.
+-}
+fail : { description : String, reason : Reason } -> Expectation
+fail { description, reason } =
+    Fail { given = Nothing, description = description, reason = reason }
+
+
 {-| Set the given (fuzz test input) of an expectation.
 -}
 withGiven : String -> Expectation -> Expectation
 withGiven newGiven expectation =
     case expectation of
         Fail failure ->
-            Fail { failure | given = newGiven }
+            Fail { failure | given = Just newGiven }
 
         Pass ->
             expectation

--- a/src/Test/Message.elm
+++ b/src/Test/Message.elm
@@ -15,7 +15,7 @@ verticalBar comparison expected actual =
         |> String.join "\n"
 
 
-failureMessage : { given : String, description : String, reason : Reason } -> String
+failureMessage : { given : Maybe String, description : String, reason : Reason } -> String
 failureMessage { given, description, reason } =
     case reason of
         Custom ->

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -23,7 +23,7 @@ expectToFail =
     expectFailureHelper (always Nothing)
 
 
-expectFailureHelper : ({ description : String, given : String, reason : Test.Expectation.Reason } -> Maybe String) -> Test -> Test
+expectFailureHelper : ({ description : String, given : Maybe String, reason : Test.Expectation.Reason } -> Maybe String) -> Test -> Test
 expectFailureHelper f test =
     case test of
         TI.Test runTest ->
@@ -67,10 +67,15 @@ testShrinking =
                 acceptable =
                     String.split "|" description
             in
-                if List.member given acceptable then
-                    Nothing
-                else
-                    Just <| "Got shrunken value " ++ given ++ " but expected " ++ String.join " or " acceptable
+                case given of
+                    Nothing ->
+                        Just "Expected this test to have a given value!"
+
+                    Just g ->
+                        if List.member g acceptable then
+                            Nothing
+                        else
+                            Just <| "Got shrunken value " ++ g ++ " but expected " ++ String.join " or " acceptable
     in
         expectFailureHelper handleFailure
 


### PR DESCRIPTION
This allows us to be more exact about whether a test was given the empty string as a fuzz input, or no given (i.e. a unit test). It also lets us remove a bit of noise from the Expect module.