### PR TITLE
Fix links to Fuzz module

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -127,7 +127,7 @@ type alias FuzzOptions =
 {-| Run a [`fuzz`](#fuzz) test with the given [`FuzzOptions`](#FuzzOptions).
 
 Note that there is no `fuzzWith2`, but you can always pass more fuzz values in
-using [`Fuzz.tuple`](../Fuzz#tuple), [`Fuzz.tuple3`](../Fuzz#tuple3),
+using [`Fuzz.tuple`](Fuzz#tuple), [`Fuzz.tuple3`](Fuzz#tuple3),
 for example like this:
 
     import Test exposing (fuzzWith)
@@ -201,7 +201,7 @@ fuzz =
 
 {-| Run a [fuzz test](#fuzz) using two random inputs.
 
-This is a convenience function that lets you skip calling [`Fuzz.tuple`](../Fuzz#tuple).
+This is a convenience function that lets you skip calling [`Fuzz.tuple`](Fuzz#tuple).
 
 See [`fuzzWith`](#fuzzWith) for an example of writing this in tuple style.
 
@@ -230,7 +230,7 @@ fuzz2 fuzzA fuzzB desc =
 
 {-| Run a [fuzz test](#fuzz) using three random inputs.
 
-This is a convenience function that lets you skip calling [`Fuzz.tuple3`](../Fuzz#tuple3).
+This is a convenience function that lets you skip calling [`Fuzz.tuple3`](Fuzz#tuple3).
 -}
 fuzz3 :
     Fuzzer a
@@ -249,7 +249,7 @@ fuzz3 fuzzA fuzzB fuzzC desc =
 
 {-| Run a [fuzz test](#fuzz) using four random inputs.
 
-This is a convenience function that lets you skip calling [`Fuzz.tuple4`](../Fuzz#tuple4).
+This is a convenience function that lets you skip calling [`Fuzz.tuple4`](Fuzz#tuple4).
 -}
 fuzz4 :
     Fuzzer a
@@ -269,7 +269,7 @@ fuzz4 fuzzA fuzzB fuzzC fuzzD desc =
 
 {-| Run a [fuzz test](#fuzz) using five random inputs.
 
-This is a convenience function that lets you skip calling [`Fuzz.tuple5`](../Fuzz#tuple5).
+This is a convenience function that lets you skip calling [`Fuzz.tuple5`](Fuzz#tuple5).
 -}
 fuzz5 :
     Fuzzer a


### PR DESCRIPTION
These links were broken on the packages website, due to linking one level higher than they should. For example, this can be seen at http://package.elm-lang.org/packages/elm-community/elm-test/3.1.0/Test#fuzz2 by clicking on the `Fuzz.tuple` link.