### PR TITLE
Make `describe "" []` fail

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -578,7 +578,10 @@ which argument is which:
 all : List (subject -> Expectation) -> subject -> Expectation
 all list query =
     if List.isEmpty list then
-        fail "Expect.all received an empty list. I assume this was due to a mistake somewhere, so I'm failing this test!"
+        Test.Expectation.fail
+            { reason = Test.Expectation.EmptyList
+            , description = "Expect.all was given an empty list. You must make at least one expectation to have a valid test!"
+            }
     else
         allHelp list query
 

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -77,10 +77,23 @@ filter =
                         |> Expect.equal [ num ]
             ]
         ]
+
+Passing an empty list will result in a failing test, because you either made a
+mistake or are creating a placeholder.
 -}
 describe : String -> List Test -> Test
-describe desc =
-    Internal.Batch >> Internal.Labeled desc
+describe desc tests =
+    if List.isEmpty tests then
+        Internal.Test
+            (\_ _ ->
+                [ Test.Expectation.fail
+                    { reason = Test.Expectation.EmptyList
+                    , description = "You tried to describe " ++ desc ++ " with no tests!"
+                    }
+                ]
+            )
+    else
+        Internal.Labeled desc (Internal.Batch tests)
 
 
 {-| Return a [`Test`](#Test) that evaluates a single

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -22,6 +22,7 @@ type Reason
         , missing : List String
         }
     | TODO
+    | EmptyList
 
 
 {-| Create a failure without specifying the given.

--- a/src/Test/Message.elm
+++ b/src/Test/Message.elm
@@ -30,6 +30,9 @@ failureMessage { given, description, reason } =
         TODO ->
             "TODO: " ++ description
 
+        EmptyList ->
+            description
+
         ListDiff e a ( i, itemE, itemA ) ->
             String.join ""
                 [ verticalBar description e a

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -20,7 +20,7 @@ import Helpers exposing (..)
 all : Test
 all =
     Test.concat
-        [ readmeExample, regressions, todoTests, expectationTests, fuzzerTests ]
+        [ readmeExample, regressions, testTests, expectationTests, fuzzerTests ]
 
 
 readmeExample : Test
@@ -83,25 +83,35 @@ expectationTests =
                     \() ->
                         Ok 12 |> Expect.err
             ]
+        , describe "Expect.all"
+            [ expectToFail <|
+                test "fails with empty list" <|
+                    \_ -> "dummy subject" |> Expect.all []
+            ]
           -- , describe "Expect.somethingElse" [ ... ]
         ]
 
 
-todoTests : Test
-todoTests =
-    describe "Test.todo"
-        [ expectToFail <| todo "a TODO test fails"
-        , test "Passes are not TODO" <|
-            \_ ->
-                Expect.pass |> Test.Runner.isTodo |> Expect.false "was true"
-        , test "Simple failures are not TODO" <|
-            \_ ->
-                Expect.fail "reason" |> Test.Runner.isTodo |> Expect.false "was true"
-        , test "Failures with TODO reason are TODO" <|
-            \_ ->
-                Test.Expectation.fail { description = "", reason = Test.Expectation.TODO }
-                    |> Test.Runner.isTodo
-                    |> Expect.true "was false"
+testTests : Test
+testTests =
+    describe "functions that create tests"
+        [ describe "describe"
+            [ expectToFail <| describe "fails with empty list" []
+            ]
+        , describe "Test.todo"
+            [ expectToFail <| todo "a TODO test fails"
+            , test "Passes are not TODO" <|
+                \_ ->
+                    Expect.pass |> Test.Runner.isTodo |> Expect.false "was true"
+            , test "Simple failures are not TODO" <|
+                \_ ->
+                    Expect.fail "reason" |> Test.Runner.isTodo |> Expect.false "was true"
+            , test "Failures with TODO reason are TODO" <|
+                \_ ->
+                    Test.Expectation.fail { description = "", reason = Test.Expectation.TODO }
+                        |> Test.Runner.isTodo
+                        |> Expect.true "was false"
+            ]
         ]
 
 


### PR DESCRIPTION
Adds an `EmptyList` term to the `Reason` type, and also use it for `Expect.all []`.

Resolves #95