### PR TITLE
Make `describe ""` fail automatically

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -579,7 +579,7 @@ all : List (subject -> Expectation) -> subject -> Expectation
 all list query =
     if List.isEmpty list then
         Test.Expectation.fail
-            { reason = Test.Expectation.EmptyList
+            { reason = Test.Expectation.Invalid Test.Expectation.EmptyList
             , description = "Expect.all was given an empty list. You must make at least one expectation to have a valid test!"
             }
     else

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -82,19 +82,23 @@ Passing an empty list will result in a failing test, because you either made a
 mistake or are creating a placeholder.
 -}
 describe : String -> List Test -> Test
-describe desc tests =
-    if desc == "" then
-        Internal.failNow
-            { description = "You must pass 'describe' a nonempty string!"
-            , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
-            }
-    else if List.isEmpty tests then
-        Internal.failNow
-            { description = "You tried to describe '" ++ desc ++ "' but included no tests!"
-            , reason = Test.Expectation.Invalid Test.Expectation.EmptyList
-            }
-    else
-        Internal.Labeled desc (Internal.Batch tests)
+describe untrimmedDesc tests =
+    let
+        desc =
+            String.trim untrimmedDesc
+    in
+        if desc == "" then
+            Internal.failNow
+                { description = "You must pass 'describe' a nonempty string!"
+                , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
+                }
+        else if List.isEmpty tests then
+            Internal.failNow
+                { description = "You tried to describe '" ++ desc ++ "' but included no tests!"
+                , reason = Test.Expectation.Invalid Test.Expectation.EmptyList
+                }
+        else
+            Internal.Labeled desc (Internal.Batch tests)
 
 
 {-| Return a [`Test`](#Test) that evaluates a single
@@ -110,14 +114,18 @@ describe desc tests =
                 |> Expect.equal 0
 -}
 test : String -> (() -> Expectation) -> Test
-test desc thunk =
-    if desc == "" then
-        Internal.failNow
-            { description = "You must pass 'test' a nonempty string!"
-            , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
-            }
-    else
-        Internal.Labeled desc (Internal.Test (\_ _ -> [ thunk () ]))
+test untrimmedDesc thunk =
+    let
+        desc =
+            String.trim untrimmedDesc
+    in
+        if desc == "" then
+            Internal.failNow
+                { description = "You must pass 'test' a nonempty string!"
+                , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
+                }
+        else
+            Internal.Labeled desc (Internal.Test (\_ _ -> [ thunk () ]))
 
 
 {-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests
@@ -191,19 +199,23 @@ for example like this:
                     |> Expect.equal (List.member target nums)
 -}
 fuzzWith : FuzzOptions -> Fuzzer a -> String -> (a -> Expectation) -> Test
-fuzzWith options fuzzer desc getTest =
-    if options.runs < 1 then
-        Internal.failNow
-            { description = "Fuzz test run count must be at least 1, not " ++ toString options.runs
-            , reason = Test.Expectation.Invalid Test.Expectation.NonpositiveFuzzCount
-            }
-    else if desc == "" then
-        Internal.failNow
-            { description = "You must pass 'test' a nonempty string!"
-            , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
-            }
-    else
-        fuzzWithHelp options (fuzz fuzzer desc getTest)
+fuzzWith options fuzzer untrimmedDesc getTest =
+    let
+        desc =
+            String.trim untrimmedDesc
+    in
+        if options.runs < 1 then
+            Internal.failNow
+                { description = "Fuzz test run count must be at least 1, not " ++ toString options.runs
+                , reason = Test.Expectation.Invalid Test.Expectation.NonpositiveFuzzCount
+                }
+        else if desc == "" then
+            Internal.failNow
+                { description = "You must pass 'test' a nonempty string!"
+                , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
+                }
+        else
+            fuzzWithHelp options (fuzz fuzzer desc getTest)
 
 
 fuzzWithHelp : FuzzOptions -> Test -> Test

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -1,4 +1,4 @@
-module Test.Expectation exposing (Expectation(..), Reason(..), fail, withGiven)
+module Test.Expectation exposing (Expectation(..), Reason(..), InvalidReason(..), fail, withGiven)
 
 
 type Expectation
@@ -22,7 +22,13 @@ type Reason
         , missing : List String
         }
     | TODO
-    | EmptyList
+    | Invalid InvalidReason
+
+
+type InvalidReason
+    = EmptyList
+    | NonpositiveFuzzCount
+    | BadDescription
 
 
 {-| Create a failure without specifying the given.

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -50,7 +50,7 @@ filterHelp lastCheckPassed isKeepable test =
 
 
 fuzzTest : Fuzzer a -> String -> (a -> Expectation) -> Test
-fuzzTest fuzzer desc getExpectation =
+fuzzTest fuzzer untrimmedDesc getExpectation =
     {- Fuzz test algorithm with opt-in RoseTrees:
        Generate a single value by passing the fuzzer True (indicates skip shrinking)
        Run the test on that value. If it fails:
@@ -61,6 +61,9 @@ fuzzTest fuzzer desc getExpectation =
        Whether it passes or fails, do this n times
     -}
     let
+        desc =
+            String.trim untrimmedDesc
+
         getFailures failures currentSeed remainingRuns =
             let
                 genVal =

--- a/src/Test/Message.elm
+++ b/src/Test/Message.elm
@@ -1,7 +1,7 @@
 module Test.Message exposing (failureMessage)
 
 import String
-import Test.Expectation exposing (Reason(..))
+import Test.Expectation exposing (Reason(..), InvalidReason(..))
 
 
 verticalBar : String -> String -> String -> String
@@ -28,9 +28,15 @@ failureMessage { given, description, reason } =
             verticalBar description e a
 
         TODO ->
-            "TODO: " ++ description
+            description
 
-        EmptyList ->
+        Invalid BadDescription ->
+            if description == "" then
+                "The empty string is not a valid name."
+            else
+                "You used an invalid name: " ++ description
+
+        Invalid _ ->
             description
 
         ListDiff e a ( i, itemE, itemA ) ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -97,6 +97,17 @@ testTests =
     describe "functions that create tests"
         [ describe "describe"
             [ expectToFail <| describe "fails with empty list" []
+            , expectToFail <| describe "" [ test "describe with empty description fail" <| \_ -> Expect.pass ]
+            ]
+        , describe "test"
+            [ expectToFail <| test "" <| \_ -> Expect.pass
+            ]
+        , describe "fuzz"
+            [ expectToFail <| fuzz Fuzz.bool "" <| \_ -> Expect.pass
+            ]
+        , describe "fuzzWith"
+            [ expectToFail <| fuzzWith { runs = 0 } Fuzz.bool "nonpositive" <| \_ -> Expect.pass
+            , expectToFail <| fuzzWith { runs = 1 } Fuzz.bool "" <| \_ -> Expect.pass
             ]
         , describe "Test.todo"
             [ expectToFail <| todo "a TODO test fails"


### PR DESCRIPTION
This PR
* Makes `describe ""`, `test ""`, and so on invalid tests that automatically fail
* Tests that they fail
* Refactors and improves the code for catching invalid test conditions, with an eye to #115 