### PR TITLE
Create invalid fuzzers; use them for frequency and numeric ranges

### DIFF
--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -28,6 +28,7 @@ type Reason
 type InvalidReason
     = EmptyList
     | NonpositiveFuzzCount
+    | InvalidFuzzer
     | BadDescription
 
 

--- a/tests/FuzzerTests.elm
+++ b/tests/FuzzerTests.elm
@@ -40,8 +40,8 @@ fuzzerTests =
             "intRange"
             (Expect.greaterThan 0)
         , fuzz
-            (frequencyOrCrash [ ( 1, intRange 1 6 ), ( 1, intRange 1 20 ) ])
-            "Fuzz.frequency(OrCrash)"
+            (frequency [ ( 1, intRange 1 6 ), ( 1, intRange 1 20 ) ])
+            "Fuzz.frequency"
             (Expect.greaterThan 0)
         , fuzz (result string int) "Fuzz.result" <| \r -> Expect.pass
         , fuzz (andThen (\i -> intRange 0 (2 ^ i)) (intRange 1 8))
@@ -74,7 +74,7 @@ fuzzerTests =
                                 , tuple3
                                     ( percentage
                                     , map2 (+) int int
-                                    , frequencyOrCrash [ ( 1, constant True ), ( 3, constant False ) ]
+                                    , frequency [ ( 1, constant True ), ( 3, constant False ) ]
                                     )
                                 , tuple3 ( intRange 0 100, floatRange -51 pi, map abs int )
                                 )

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -1,4 +1,4 @@
-module Helpers exposing (testStringLengthIsPreserved, expectToFail, testShrinking, randomSeedFuzzer, succeeded)
+module Helpers exposing (passingTest, testStringLengthIsPreserved, expectToFail, testShrinking, randomSeedFuzzer, succeeded)
 
 import Test exposing (Test)
 import Test.Expectation exposing (Expectation(..))
@@ -8,6 +8,11 @@ import String
 import Expect
 import Random.Pcg as Random
 import Shrink
+
+
+passingTest : a -> Expectation
+passingTest _ =
+    Expect.pass
 
 
 testStringLengthIsPreserved : List String -> Expectation

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -108,10 +108,7 @@ testTests =
         , describe "Test.todo"
             [ expectToFail <| todo "a TODO test fails"
             , test "Passes are not TODO"
-                (passingTest
-                    >> Test.Runner.isTodo
-                    >> Expect.false "was true"
-                )
+                (\_ -> Expect.pass |> Test.Runner.isTodo |> Expect.false "was true")
             , test "Simple failures are not TODO" <|
                 \_ ->
                     Expect.fail "reason" |> Test.Runner.isTodo |> Expect.false "was true"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -93,23 +93,25 @@ testTests =
     describe "functions that create tests"
         [ describe "describe"
             [ expectToFail <| describe "fails with empty list" []
-            , expectToFail <| describe "" [ test "describe with empty description fail" <| \_ -> Expect.pass ]
+            , expectToFail <| describe "" [ test "describe with empty description fail" <| passingTest ]
             ]
         , describe "test"
-            [ expectToFail <| test "" <| \_ -> Expect.pass
+            [ expectToFail <| test "" passingTest
             ]
         , describe "fuzz"
-            [ expectToFail <| fuzz Fuzz.bool "" <| \_ -> Expect.pass
+            [ expectToFail <| fuzz Fuzz.bool "" passingTest
             ]
         , describe "fuzzWith"
-            [ expectToFail <| fuzzWith { runs = 0 } Fuzz.bool "nonpositive" <| \_ -> Expect.pass
-            , expectToFail <| fuzzWith { runs = 1 } Fuzz.bool "" <| \_ -> Expect.pass
+            [ expectToFail <| fuzzWith { runs = 0 } Fuzz.bool "nonpositive" passingTest
+            , expectToFail <| fuzzWith { runs = 1 } Fuzz.bool "" passingTest
             ]
         , describe "Test.todo"
             [ expectToFail <| todo "a TODO test fails"
-            , test "Passes are not TODO" <|
-                \_ ->
-                    Expect.pass |> Test.Runner.isTodo |> Expect.false "was true"
+            , test "Passes are not TODO"
+                (passingTest
+                    >> Test.Runner.isTodo
+                    >> Expect.false "was true"
+                )
             , test "Simple failures are not TODO" <|
                 \_ ->
                     Expect.fail "reason" |> Test.Runner.isTodo |> Expect.false "was true"


### PR DESCRIPTION
Allows for fuzzers to be invalid. Handle and test all of the places where that comes up, since an invalid fuzzer should cause an immediate test failure. Then use invalid fuzzers when one passes bad arguments to a fuzzer building function. Also expose `Fuzz.invalid` for others to use.

Fixes #116.