### PR TITLE
Fix minor typo in Expect.all documentation

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -660,7 +660,7 @@ will always return a failed expectation no matter what else it is passed.
     -- Passes because (0 > -2) is True and (0 < 5) is also True
 Failures resemble code written in pipeline style, so you can tell
 which argument is which:
-    -- Fails because (0 > -10) is False
+    -- Fails because (0 < -10) is False
     List.length []
         |> Expect.all
             [ Expect.greaterThan -2


### PR DESCRIPTION
The documentation is meant to describe how the example assertion fails because the statement “0 is less than -10” is false. However it currently reads “0 is greater than -10” which is actually true :)