### PR TITLE
Bugfix: finding memoized value skips remaining tests

### DIFF
--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -91,21 +91,20 @@ getFailures fuzzer getExpectation initialSeed totalRuns =
             let
                 ( value, nextSeed ) =
                     Random.step genVal currentSeed
-            in
-                case Dict.get (toString value) state.results of
-                    Just _ ->
-                        -- we can skip this, already have the result in `failures`
-                        state.failures
 
-                    Nothing ->
-                        let
-                            newState =
-                                findNewFailure fuzzer getExpectation state currentSeed value
-                        in
-                            if remainingRuns == 1 then
-                                newState.failures
-                            else
-                                helper nextSeed (remainingRuns - 1) newState
+                newState =
+                    case Dict.get (toString value) state.results of
+                        Just _ ->
+                            -- we can skip this, already have the result in `state`
+                            state
+
+                        Nothing ->
+                            findNewFailure fuzzer getExpectation state currentSeed value
+            in
+                if remainingRuns == 1 then
+                    newState.failures
+                else
+                    helper nextSeed (remainingRuns - 1) newState
     in
         helper initialSeed totalRuns initialState
 


### PR DESCRIPTION
Fix issue where hitting a known fuzzed value would skip the rest of the tests. Instead, do nothing for that test, but continue with the remaining tests.

It's tempting to not count this as a test at all to ensure we hit n distinct results, but not all fuzzers generate 100 distinct values (e.g. `Fuzz.bool`). But, if `Fuzz.int` generates `0` for the second time on the 12th test, we shouldn't skip the remaining 88.

@Janiczek Please rerun your benchmarks and see if the perf gains from #119 are still present. Sorry I didn't spot this bug earlier; it only became visible after #126.