### PR TITLE
Add (failing) regression test for fuzzers not running n times

### DIFF
--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -57,15 +57,8 @@ validatedFuzzTest fuzzer desc getExpectation =
         Labeled desc (Test run)
 
 
-type ShrinkingResult a
-    = Passes
-    | ShrinksTo a
-
-
-type alias State a =
-    { failures : Dict String Expectation
-    , results : Dict String (ShrinkingResult a)
-    }
+type alias Failures =
+    Dict String Expectation
 
 
 getFailures : Fuzzer a -> (a -> Expectation) -> Random.Seed -> Int -> Dict String Expectation
@@ -84,30 +77,24 @@ getFailures fuzzer getExpectation initialSeed totalRuns =
         genVal =
             unpackGenVal fuzzer
 
-        initialState =
-            State Dict.empty Dict.empty
+        initialFailures =
+            Dict.empty
 
-        helper currentSeed remainingRuns state =
+        helper currentSeed remainingRuns failures =
             let
                 ( value, nextSeed ) =
                     Random.step genVal currentSeed
             in
-                case Dict.get (toString value) state.results of
-                    Just _ ->
-                        -- we can skip this, already have the result in `failures`
-                        state.failures
-
-                    Nothing ->
-                        let
-                            newState =
-                                findNewFailure fuzzer getExpectation state currentSeed value
-                        in
-                            if remainingRuns == 1 then
-                                newState.failures
-                            else
-                                helper nextSeed (remainingRuns - 1) newState
+                let
+                    newFailures =
+                        findNewFailure fuzzer getExpectation failures currentSeed value
+                in
+                    if remainingRuns == 1 then
+                        newFailures
+                    else
+                        helper nextSeed (remainingRuns - 1) newFailures
     in
-        helper initialSeed totalRuns initialState
+        helper initialSeed totalRuns initialFailures
 
 
 {-| Knowing that a value in not in the cache, determine if it causes the test to pass or fail.
@@ -115,14 +102,14 @@ getFailures fuzzer getExpectation initialSeed totalRuns =
 findNewFailure :
     Fuzzer a
     -> (a -> Expectation)
-    -> State a
+    -> Failures
     -> Random.Seed
     -> a
-    -> State a
-findNewFailure fuzzer getExpectation state currentSeed value =
+    -> Failures
+findNewFailure fuzzer getExpectation failures currentSeed value =
     case getExpectation value of
         Pass ->
-            { state | results = Dict.insert (toString value) Passes state.results }
+            failures
 
         failedExpectation ->
             let
@@ -133,68 +120,49 @@ findNewFailure fuzzer getExpectation state currentSeed value =
                     -- nextSeed is not used here because caller function has currentSeed
                     Random.step genTree currentSeed
             in
-                shrinkAndAdd rosetree getExpectation failedExpectation state
+                shrinkAndAdd rosetree getExpectation failedExpectation failures
 
 
-{-| Knowing that the rosetree's root already failed, but that it's not in the results cache, finds the shrunken failure.
-Returns the updated state (failures dictionary and results cache dictionary).
+{-| Knowing that the rosetree's root already failed, finds the shrunken failure.
+Returns the updated failures dictionary.
 -}
 shrinkAndAdd :
     RoseTree a
     -> (a -> Expectation)
     -> Expectation
-    -> State a
-    -> State a
-shrinkAndAdd rootTree getExpectation rootsExpectation { failures, results } =
+    -> Failures
+    -> Failures
+shrinkAndAdd rootTree getExpectation rootsExpectation failures =
     let
-        shrink oldExpectation (Rose failingValue branches) results =
+        shrink : Expectation -> RoseTree a -> ( a, Expectation )
+        shrink oldExpectation (Rose failingValue branches) =
             case Lazy.List.headAndTail branches of
                 Just ( (Rose possiblyFailingValue _) as rosetree, moreLazyRoseTrees ) ->
                     -- either way, recurse with the most recent failing expectation, and failing input with its list of shrunken values
-                    case Dict.get (toString possiblyFailingValue) results of
-                        Just result ->
-                            case result of
-                                Passes ->
-                                    shrink oldExpectation (Rose failingValue moreLazyRoseTrees) results
+                    case getExpectation possiblyFailingValue of
+                        Pass ->
+                            shrink oldExpectation
+                                (Rose failingValue moreLazyRoseTrees)
 
-                                ShrinksTo minimalValue ->
-                                    ( minimalValue, oldExpectation, results )
-
-                        Nothing ->
-                            case getExpectation possiblyFailingValue of
-                                Pass ->
-                                    shrink oldExpectation
-                                        (Rose failingValue moreLazyRoseTrees)
-                                        (Dict.insert (toString possiblyFailingValue) Passes results)
-
-                                newExpectation ->
-                                    let
-                                        ( minimalValue, finalExpectation, newResults ) =
-                                            shrink newExpectation rosetree results
-                                    in
-                                        ( minimalValue
-                                        , finalExpectation
-                                        , newResults
-                                            |> Dict.insert (toString possiblyFailingValue) (ShrinksTo minimalValue)
-                                            |> Dict.insert (toString failingValue) (ShrinksTo minimalValue)
-                                        )
+                        newExpectation ->
+                            let
+                                ( minimalValue, finalExpectation ) =
+                                    shrink newExpectation rosetree
+                            in
+                                ( minimalValue
+                                , finalExpectation
+                                )
 
                 Nothing ->
-                    ( failingValue
-                    , oldExpectation
-                    , Dict.insert (toString failingValue) (ShrinksTo failingValue) results
-                      -- minimal value!
-                    )
+                    ( failingValue, oldExpectation )
 
         (Rose failingValue _) =
             rootTree
 
-        ( minimalValue, finalExpectation, newResults ) =
-            shrink rootsExpectation rootTree results
+        ( minimalValue, finalExpectation ) =
+            shrink rootsExpectation rootTree
     in
-        { failures = Dict.insert (toString minimalValue) finalExpectation failures
-        , results = Dict.insert (toString failingValue) (ShrinksTo minimalValue) newResults
-        }
+        Dict.insert (toString minimalValue) finalExpectation failures
 
 
 formatExpectation : ( String, Expectation ) -> Expectation

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -93,12 +93,9 @@ regressions =
             (Expect.notEqual 5)
             |> expectToFail
           {- If fuzz tests actually run 100 times, then asserting that no number
-             in 1..8 equals 5 is virtually guaranteed to fail. If they only run
-             once, or stop after a duplicate due to #127, then it's fairly
-             likely that the 5 won't turn up. The test will pass when it's
-             expected to fail. It's still posible the 5 comes up first, so this
-             test sometimes passes when it should fail. But unless you run it
-             millions of times, it won't fail when it should pass.
+             in 1..8 equals 5 fails with 0.999998 probability. If they only run
+             once, or stop after a duplicate due to #127, then it's much more
+             likely (but not guaranteed) that the 5 won't turn up. See #128.
           -}
         ]
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -85,6 +85,19 @@ regressions =
             \positiveInt ->
                 positiveInt
                     |> Expect.greaterThan 0
+        , fuzz
+            (intRange 1 20)
+            "fuzz tests run 100 times"
+            (Expect.notEqual 5)
+            |> expectToFail
+          {- If fuzz tests actually run 100 times, then asserting that no number
+             in 1..20 equals 5 is virtually guaranteed to fail. If they only run
+             once, or stop after a duplicate due to #127, then it's fairly
+             likely that the 5 won't turn up. The test will pass when it's
+             expected to fail. It's still posible the 5 comes up first, so this
+             test sometimes passes when it should fail. But unless you run it
+             millions of times, it won't fail when it should pass.
+          -}
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -6,6 +6,8 @@ import Test.Runner
 import Fuzz exposing (..)
 import Dict
 import Set
+import Random.Pcg as Random
+import Shrink
 import Expect
 import Helpers exposing (..)
 import ExpectWithinTests exposing (testExpectWithin)
@@ -86,12 +88,12 @@ regressions =
                 positiveInt
                     |> Expect.greaterThan 0
         , fuzz
-            (intRange 1 20)
+            (custom (Random.int 1 8) Shrink.noShrink)
             "fuzz tests run 100 times"
             (Expect.notEqual 5)
             |> expectToFail
           {- If fuzz tests actually run 100 times, then asserting that no number
-             in 1..20 equals 5 is virtually guaranteed to fail. If they only run
+             in 1..8 equals 5 is virtually guaranteed to fail. If they only run
              once, or stop after a duplicate due to #127, then it's fairly
              likely that the 5 won't turn up. The test will pass when it's
              expected to fail. It's still posible the 5 comes up first, so this


### PR DESCRIPTION
If fuzz tests actually run 100 times, then asserting that no number in 1..20 equals 5 is virtually guaranteed to fail. If they only run once, or stop after a duplicate due to #127, then it's fairly likely that the 5 won't turn up. The test will pass when it's expected to fail. It's still posible the 5 comes up first, so this test sometimes passes when it should fail. But unless you run it millions of times, it won't fail when it should pass.

This test fails on current master, passes on pre-#119 master, and passes on #127.