### PR TITLE
Correct spelling.

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -644,7 +644,7 @@ constant x =
         )
 
 
-{-| Map a function over a fuzzer. This applies to both the generated and the shruken values.
+{-| Map a function over a fuzzer. This applies to both the generated and the shrunken values.
 -}
 map : (a -> b) -> Fuzzer a -> Fuzzer b
 map transform (Internal.Fuzzer baseFuzzer) =
@@ -692,7 +692,7 @@ map5 transform fuzzA fuzzB fuzzC fuzzD fuzzE =
 
 {-| Map over many fuzzers. This can act as mapN for N > 5.
 
-The argument order is meant to accomodate chaining:
+The argument order is meant to accommodate chaining:
 
     map f aFuzzer
         |> andMap anotherFuzzer
@@ -808,7 +808,7 @@ you could do this:
 There are a few circumstances in which this function will return an invalid
 fuzzer, which causes it to fail any test that uses it:
 
-* If you provide an empy list of frequencies
+* If you provide an empty list of frequencies
 * If any of the weights are less than 0
 * If the weights sum to 0
 

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -140,7 +140,7 @@ distributeSeeds runs test ( startingSeed, runners ) =
 
 If it is a [`fail`](#fail), return a record containing the failure message,
 along with the given inputs if it was a fuzz test. (If no inputs were involved,
-the record's `given` field will be `Nothign`).
+the record's `given` field will be `Nothing`).
 
 For example, if a fuzz test generates random integers, this might return
 `{ message = "it was supposed to be positive", given = "-1" }`

--- a/tests/FuzzerTests.elm
+++ b/tests/FuzzerTests.elm
@@ -143,7 +143,7 @@ manualFuzzerTests =
         [ fuzz randomSeedFuzzer "Claim there are no even numbers" <|
             \seed ->
                 let
-                    -- fuzzer is gauranteed to produce an even number
+                    -- fuzzer is guaranteed to produce an even number
                     fuzzer =
                         Fuzz.intRange 2 10000
                             |> Fuzz.map


### PR DESCRIPTION
I saw some spelling errors, so I ran a spellcheck against the codebase using an american dictionary. 