### PR TITLE
Broaden copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2017 Richard Feldman and Max Goldstein
+Copyright (c) 2016-2017 the Elm-test contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Broadens the copyright notice according to #129. Let me know if the wording should be changed. 