### PR TITLE
Fail tests with duplicate names 

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -35,8 +35,16 @@ type alias Test =
     concat [ testDecoder, testSorting ]
 -}
 concat : List Test -> Test
-concat =
-    Internal.Batch
+concat tests =
+    case Internal.duplicatedName tests of
+        Err duped ->
+            Internal.failNow
+                { description = "A test group contains multiple tests named '" ++ duped ++ "'. Do some renaming so that tests have unique names."
+                , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
+                }
+
+        Ok _ ->
+            Internal.Batch tests
 
 
 {-| Remove any test unless its description satisfies the given predicate

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -13,6 +13,7 @@ module Test exposing (Test, FuzzOptions, describe, test, filter, concat, todo, f
 @docs fuzz, fuzz2, fuzz3, fuzz4, fuzz5, fuzzWith, FuzzOptions
 -}
 
+import Set
 import Test.Internal as Internal
 import Test.Expectation
 import Test.Fuzz
@@ -106,8 +107,14 @@ describe untrimmedDesc tests =
                         , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
                         }
 
-                Ok _ ->
-                    Internal.Labeled desc (Internal.Batch tests)
+                Ok childrenNames ->
+                    if Set.member desc childrenNames then
+                        Internal.failNow
+                            { description = "The test '" ++ desc ++ "' contains a child test of the same name. Do some renaming so that tests have distinct names."
+                            , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
+                            }
+                    else
+                        Internal.Labeled desc (Internal.Batch tests)
 
 
 {-| Return a [`Test`](#Test) that evaluates a single

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -99,7 +99,15 @@ describe untrimmedDesc tests =
                 , reason = Test.Expectation.Invalid Test.Expectation.EmptyList
                 }
         else
-            Internal.Labeled desc (Internal.Batch tests)
+            case Internal.duplicatedName tests of
+                Err duped ->
+                    Internal.failNow
+                        { description = "The tests '" ++ desc ++ "' contains multiple tests named '" ++ duped ++ "'. Do some renaming so that tests have unique names."
+                        , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
+                        }
+
+                Ok _ ->
+                    Internal.Labeled desc (Internal.Batch tests)
 
 
 {-| Return a [`Test`](#Test) that evaluates a single

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -30,6 +30,7 @@ type InvalidReason
     | NonpositiveFuzzCount
     | InvalidFuzzer
     | BadDescription
+    | DuplicatedName
 
 
 {-| Create a failure without specifying the given.

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -45,7 +45,7 @@ filterHelp lastCheckPassed isKeepable test =
 
 
 duplicatedName : List Test -> Result String (Set String)
-duplicatedName tests =
+duplicatedName =
     let
         names : Test -> List String
         names test =
@@ -69,5 +69,5 @@ duplicatedName tests =
                         Ok <| Set.insert newName oldNames
                 )
     in
-        List.concatMap names tests
-            |> List.foldl insertOrFail (Ok Set.empty)
+        List.concatMap names
+            >> List.foldl insertOrFail (Ok Set.empty)

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -44,7 +44,7 @@ filterHelp lastCheckPassed isKeepable test =
                 |> Batch
 
 
-duplicatedName : List Test -> Result String ()
+duplicatedName : List Test -> Result String (Set String)
 duplicatedName tests =
     let
         name : Test -> Maybe String
@@ -73,4 +73,4 @@ duplicatedName tests =
                             else
                                 helper (Set.insert aName set) ts
     in
-        helper Set.empty tests |> Result.map (always ())
+        helper Set.empty tests

--- a/tests/ExpectWithinTests.elm
+++ b/tests/ExpectWithinTests.elm
@@ -106,11 +106,11 @@ testExpectWithin =
                     Float.nan |> Expect.notWithin (abs epsilon) Float.nan
             ]
         , describe "zero tolerance"
-            [ fuzz float "self-equality with zero tolerance" <|
+            [ fuzz float "a float is within 0 of itself" <|
                 -- U zero epsilon equals self
                 \a ->
                     a |> Expect.within 0 a
-            , fuzz2 float float "self-equality with zero tolerance" <|
+            , fuzz2 float float "floats are within 0 iff they are equal" <|
                 -- F zero epsilon does not equal anything other than self
                 \a b ->
                     if a == b then

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -118,7 +118,14 @@ testTests =
                         |> Test.Runner.isTodo
                         |> Expect.true "was false"
             ]
-        , expectToFail <|
+        , identicalNamesAreRejectedTests
+        ]
+
+
+identicalNamesAreRejectedTests : Test
+identicalNamesAreRejectedTests =
+    describe "Identically-named sibling and parent/child tests fail"
+        [ expectToFail <|
             describe "a describe with two identically named children fails"
                 [ test "foo" passingTest
                 , test "foo" passingTest
@@ -131,5 +138,32 @@ testTests =
             describe "a describe with the same name as a child describe fails"
                 [ describe "a describe with the same name as a child describe fails"
                     [ test "a test" passingTest ]
+                ]
+        , expectToFail <|
+            Test.concat
+                [ describe "a describe with the same name as a sibling describe fails"
+                    [ test "a test" passingTest ]
+                , describe "a describe with the same name as a sibling describe fails"
+                    [ test "another test" passingTest ]
+                ]
+        , expectToFail <|
+            Test.concat
+                [ Test.concat
+                    [ describe "a describe with the same name as a de facto sibling describe fails"
+                        [ test "a test" passingTest ]
+                    ]
+                , describe "a describe with the same name as a de facto sibling describe fails"
+                    [ test "another test" passingTest ]
+                ]
+        , expectToFail <|
+            Test.concat
+                [ Test.concat
+                    [ describe "a describe with the same name as a de facto sibling describe fails"
+                        [ test "a test" passingTest ]
+                    ]
+                , Test.concat
+                    [ describe "a describe with the same name as a de facto sibling describe fails"
+                        [ test "another test" passingTest ]
+                    ]
                 ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -118,4 +118,9 @@ testTests =
                         |> Test.Runner.isTodo
                         |> Expect.true "was false"
             ]
+        , expectToFail <|
+            describe "a describe with two identically named children fails"
+                [ test "foo" passingTest
+                , test "foo" passingTest
+                ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -123,4 +123,13 @@ testTests =
                 [ test "foo" passingTest
                 , test "foo" passingTest
                 ]
+        , expectToFail <|
+            describe "a describe with the same name as a child test fails"
+                [ test "a describe with the same name as a child test fails" passingTest
+                ]
+        , expectToFail <|
+            describe "a describe with the same name as a child describe fails"
+                [ describe "a describe with the same name as a child describe fails"
+                    [ test "a test" passingTest ]
+                ]
         ]


### PR DESCRIPTION
Implements #115: automatically fail tests with duplicated names across parents/children and siblings. Test that this works. Rename a pair of tests in our suite that broke this rule.

👀  @rtfeldman @jfmengels