### PR TITLE
Revert memoization

### DIFF
--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -134,7 +134,7 @@ shrinkAndAdd :
     -> Failures
 shrinkAndAdd rootTree getExpectation rootsExpectation failures =
     let
-        -- needs annotation
+        shrink : Expectation -> RoseTree a -> ( a, Expectation )
         shrink oldExpectation (Rose failingValue branches) =
             case Lazy.List.headAndTail branches of
                 Just ( (Rose possiblyFailingValue _) as rosetree, moreLazyRoseTrees ) ->


### PR DESCRIPTION
Note that this targets the regression test #128 so we can confirm that fix without breaking the master build.

@drathier Any red flags here? Do your perf tests on this branch match what we had originally?

@Janiczek, you're welcome to take another swing at perf optimization, but it's time to back out of this implementation. Thanks for your work.