### PR TITLE
Polish Failure Messages

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -36,15 +36,21 @@ type alias Test =
 -}
 concat : List Test -> Test
 concat tests =
-    case Internal.duplicatedName tests of
-        Err duped ->
-            Internal.failNow
-                { description = "A test group contains multiple tests named '" ++ duped ++ "'. Do some renaming so that tests have unique names."
-                , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
-                }
+    if List.isEmpty tests then
+        Internal.failNow
+            { description = "This `concat` has no tests in it. Let's give it some!"
+            , reason = Test.Expectation.Invalid Test.Expectation.EmptyList
+            }
+    else
+        case Internal.duplicatedName tests of
+            Err duped ->
+                Internal.failNow
+                    { description = "A test group contains multiple tests named '" ++ duped ++ "'. Do some renaming so that tests have unique names."
+                    , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
+                    }
 
-        Ok _ ->
-            Internal.Batch tests
+            Ok _ ->
+                Internal.Batch tests
 
 
 {-| Remove any test unless its description satisfies the given predicate
@@ -99,26 +105,26 @@ describe untrimmedDesc tests =
     in
         if desc == "" then
             Internal.failNow
-                { description = "You must pass 'describe' a nonempty string!"
+                { description = "This `describe` has an empty description string. Let's give it a nonempty one!"
                 , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
                 }
         else if List.isEmpty tests then
             Internal.failNow
-                { description = "You tried to describe '" ++ desc ++ "' but included no tests!"
+                { description = "This `describe " ++ toString desc ++ "` has no tests in it. Let's give it some!"
                 , reason = Test.Expectation.Invalid Test.Expectation.EmptyList
                 }
         else
             case Internal.duplicatedName tests of
                 Err duped ->
                     Internal.failNow
-                        { description = "The tests '" ++ desc ++ "' contains multiple tests named '" ++ duped ++ "'. Do some renaming so that tests have unique names."
+                        { description = "The tests '" ++ desc ++ "' contains multiple tests named '" ++ duped ++ "'. Let's do some renaming so that tests have unique names."
                         , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
                         }
 
                 Ok childrenNames ->
                     if Set.member desc childrenNames then
                         Internal.failNow
-                            { description = "The test '" ++ desc ++ "' contains a child test of the same name. Do some renaming so that tests have distinct names."
+                            { description = "The test '" ++ desc ++ "' contains a child test of the same name. Let's do some renaming so that tests have distinct names."
                             , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
                             }
                     else
@@ -145,7 +151,7 @@ test untrimmedDesc thunk =
     in
         if desc == "" then
             Internal.failNow
-                { description = "You must pass 'test' a nonempty string!"
+                { description = "This test has empty description string. Let's give it a nonempty one!"
                 , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
                 }
         else
@@ -230,12 +236,12 @@ fuzzWith options fuzzer untrimmedDesc getTest =
     in
         if options.runs < 1 then
             Internal.failNow
-                { description = "Fuzz test run count must be at least 1, not " ++ toString options.runs
+                { description = "Fuzz tests must have a run count of at least 1, not " ++ toString options.runs
                 , reason = Test.Expectation.Invalid Test.Expectation.NonpositiveFuzzCount
                 }
         else if desc == "" then
             Internal.failNow
-                { description = "You must pass 'test' a nonempty string!"
+                { description = "This test has empty description string. Let's give it a nonempty one!"
                 , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
                 }
         else

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -149,11 +149,8 @@ test untrimmedDesc thunk =
         desc =
             String.trim untrimmedDesc
     in
-        if desc == "" then
-            Internal.failNow
-                { description = "This test has empty description string. Let's give it a nonempty one!"
-                , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
-                }
+        if String.isEmpty desc then
+            Internal.emptyDescriptionFailure
         else
             Internal.Labeled desc (Internal.Test (\_ _ -> [ thunk () ]))
 

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -103,9 +103,9 @@ describe untrimmedDesc tests =
         desc =
             String.trim untrimmedDesc
     in
-        if desc == "" then
+        if String.isEmpty desc then
             Internal.failNow
-                { description = "This `describe` has an empty description string. Let's give it a nonempty one!"
+                { description = "This `describe` has a blank description. Let's give it a useful one!"
                 , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
                 }
         else if List.isEmpty tests then
@@ -150,7 +150,7 @@ test untrimmedDesc thunk =
             String.trim untrimmedDesc
     in
         if String.isEmpty desc then
-            Internal.emptyDescriptionFailure
+            Internal.blankDescriptionFailure
         else
             Internal.Labeled desc (Internal.Test (\_ _ -> [ thunk () ]))
 

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -229,7 +229,7 @@ fuzzWith : FuzzOptions -> Fuzzer a -> String -> (a -> Expectation) -> Test
 fuzzWith options fuzzer desc getTest =
     if options.runs < 1 then
         Internal.failNow
-            { description = "Fuzz tests must have a run count of at least 1, not " ++ toString options.runs
+            { description = "Fuzz tests must have a run count of at least 1, not " ++ toString options.runs ++ "."
             , reason = Test.Expectation.Invalid Test.Expectation.NonpositiveFuzzCount
             }
     else

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -229,23 +229,14 @@ for example like this:
                     |> Expect.equal (List.member target nums)
 -}
 fuzzWith : FuzzOptions -> Fuzzer a -> String -> (a -> Expectation) -> Test
-fuzzWith options fuzzer untrimmedDesc getTest =
-    let
-        desc =
-            String.trim untrimmedDesc
-    in
-        if options.runs < 1 then
-            Internal.failNow
-                { description = "Fuzz tests must have a run count of at least 1, not " ++ toString options.runs
-                , reason = Test.Expectation.Invalid Test.Expectation.NonpositiveFuzzCount
-                }
-        else if desc == "" then
-            Internal.failNow
-                { description = "This test has empty description string. Let's give it a nonempty one!"
-                , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
-                }
-        else
-            fuzzWithHelp options (fuzz fuzzer desc getTest)
+fuzzWith options fuzzer desc getTest =
+    if options.runs < 1 then
+        Internal.failNow
+            { description = "Fuzz tests must have a run count of at least 1, not " ++ toString options.runs
+            , reason = Test.Expectation.Invalid Test.Expectation.NonpositiveFuzzCount
+            }
+    else
+        fuzzWithHelp options (fuzz fuzzer desc getTest)
 
 
 fuzzWithHelp : FuzzOptions -> Test -> Test

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -117,14 +117,14 @@ describe untrimmedDesc tests =
             case Internal.duplicatedName tests of
                 Err duped ->
                     Internal.failNow
-                        { description = "The tests '" ++ desc ++ "' contains multiple tests named '" ++ duped ++ "'. Let's do some renaming so that tests have unique names."
+                        { description = "The tests '" ++ desc ++ "' contain multiple tests named '" ++ duped ++ "'. Let's rename them so we know which is which."
                         , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
                         }
 
                 Ok childrenNames ->
                     if Set.member desc childrenNames then
                         Internal.failNow
-                            { description = "The test '" ++ desc ++ "' contains a child test of the same name. Let's do some renaming so that tests have distinct names."
+                            { description = "The test '" ++ desc ++ "' contains a child test of the same name. Let's rename them so we know which is which."
                             , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
                             }
                     else

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -2,7 +2,7 @@ module Test.Fuzz exposing (fuzzTest)
 
 import Dict exposing (Dict)
 import Test.Expectation exposing (Expectation(..))
-import Test.Internal exposing (Test(..), failNow)
+import Test.Internal exposing (Test(..), failNow, emptyDescriptionFailure)
 import Fuzz exposing (Fuzzer)
 import Fuzz.Internal exposing (unpackGenVal, unpackGenTree)
 import RoseTree exposing (RoseTree(..))
@@ -18,11 +18,8 @@ fuzzTest ((Fuzz.Internal.Fuzzer baseFuzzer) as fuzzer) untrimmedDesc getExpectat
         desc =
             String.trim untrimmedDesc
     in
-        if desc == "" then
-            failNow
-                { description = "You must pass your fuzz tests a nonempty string!"
-                , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
-                }
+        if String.isEmpty desc then
+            emptyDescriptionFailure
         else
             case Fuzz.Internal.invalidReason (baseFuzzer True) of
                 Just reason ->

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -2,7 +2,7 @@ module Test.Fuzz exposing (fuzzTest)
 
 import Dict exposing (Dict)
 import Test.Expectation exposing (Expectation(..))
-import Test.Internal exposing (Test(..), failNow, emptyDescriptionFailure)
+import Test.Internal exposing (Test(..), failNow, blankDescriptionFailure)
 import Fuzz exposing (Fuzzer)
 import Fuzz.Internal exposing (unpackGenVal, unpackGenTree)
 import RoseTree exposing (RoseTree(..))
@@ -19,7 +19,7 @@ fuzzTest ((Fuzz.Internal.Fuzzer baseFuzzer) as fuzzer) untrimmedDesc getExpectat
             String.trim untrimmedDesc
     in
         if String.isEmpty desc then
-            emptyDescriptionFailure
+            blankDescriptionFailure
         else
             case Fuzz.Internal.invalidReason (baseFuzzer True) of
                 Just reason ->

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -1,4 +1,4 @@
-module Test.Internal exposing (Test(..), failNow, filter, duplicatedName)
+module Test.Internal exposing (Test(..), failNow, filter, duplicatedName, emptyDescriptionFailure)
 
 import Random.Pcg as Random exposing (Generator)
 import Test.Expectation exposing (Expectation(..))
@@ -17,6 +17,14 @@ failNow : { description : String, reason : Test.Expectation.Reason } -> Test
 failNow record =
     Test
         (\_ _ -> [ Test.Expectation.fail record ])
+
+
+emptyDescriptionFailure : Test
+emptyDescriptionFailure =
+    failNow
+        { description = "This test has an empty description. Let's give it a nonempty one!"
+        , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
+        }
 
 
 filter : (String -> Bool) -> Test -> Test

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -1,4 +1,4 @@
-module Test.Internal exposing (Test(..), failNow, filter, duplicatedName, emptyDescriptionFailure)
+module Test.Internal exposing (Test(..), failNow, filter, duplicatedName, blankDescriptionFailure)
 
 import Random.Pcg as Random exposing (Generator)
 import Test.Expectation exposing (Expectation(..))
@@ -19,10 +19,10 @@ failNow record =
         (\_ _ -> [ Test.Expectation.fail record ])
 
 
-emptyDescriptionFailure : Test
-emptyDescriptionFailure =
+blankDescriptionFailure : Test
+blankDescriptionFailure =
     failNow
-        { description = "This test has an empty description. Let's give it a nonempty one!"
+        { description = "This test has a blank description. Let's give it a useful one!"
         , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
         }
 

--- a/src/Test/Message.elm
+++ b/src/Test/Message.elm
@@ -32,9 +32,9 @@ failureMessage { given, description, reason } =
 
         Invalid BadDescription ->
             if description == "" then
-                "The empty string is not a valid name."
+                "The empty string is not a valid test description."
             else
-                "You used an invalid name: " ++ description
+                "This is an invalid test description: " ++ description
 
         Invalid _ ->
             description


### PR DESCRIPTION
I noticed a few opportunities for cleanup while working on `Test.only`. None of these should affect any behavior other than validations.

* Giving `Test.concat` a "no empty list" validation
* A case where we were checking for empty description twice
* Using a consistent error message between unit tests and fuzz tests with no description
* Making messages a bit friendlier