### PR TITLE
Test.only and Test.skip

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -1,4 +1,4 @@
-module Test exposing (Test, FuzzOptions, describe, test, concat, todo, fuzz, fuzz2, fuzz3, fuzz4, fuzz5, fuzzWith)
+module Test exposing (Test, FuzzOptions, describe, test, concat, todo, skip, only, fuzz, fuzz2, fuzz3, fuzz4, fuzz5, fuzzWith)
 
 {-| A module containing functions for creating and managing tests.
 
@@ -6,7 +6,7 @@ module Test exposing (Test, FuzzOptions, describe, test, concat, todo, fuzz, fuz
 
 ## Organizing Tests
 
-@docs describe, concat, todo
+@docs describe, concat, todo, skip, only
 
 ## Fuzz Testing
 
@@ -165,7 +165,7 @@ todo desc =
 
 These tests aren't meant to be committed to version control. Instead, use them
 when you want to focus on getting a particular subset of your tests to pass.
-If you use `Test.only`, your entire test suite is guaranteed to fail, even if
+If you use `Test.only`, your entire test suite will fail, even if
 each of the individual tests pass. This is to help avoid accidentally
 committing a `Test.only` to version control.
 
@@ -173,6 +173,7 @@ If you you use `Test.only` on multiple tests, only those tests will run. If you
 put a `Test.only` inside another `Test.only`, only the outermost `Test.only`
 will affect which tests gets run.
 
+See also [`Test.skip`](#skip)
 
     describe "List"
         [ Test.only <| describe "reverse"
@@ -194,6 +195,39 @@ will affect which tests gets run.
 only : Test -> Test
 only =
     Internal.Only
+
+
+{-| Returns a [`Test`](#Test) that gets skipped.
+
+These tests aren't meant to be committed to version control. Instead, use them
+when you want to focus on getting a particular subset of your tests to pass.
+If you use `Test.skip`, your entire test suite will fail, even if
+each of the individual tests pass. This is to help avoid accidentally
+committing a `Test.skip` to version control.
+
+See also [`Test.only`](#only)
+
+
+    describe "List"
+        [ Test.skip <| describe "reverse"
+            [ test "has no effect on an empty list" <|
+                \() ->
+                    List.reverse []
+                        |> Expect.equal []
+            , fuzz int "has no effect on a one-item list" <|
+                \num ->
+                     List.reverse [ num ]
+                        |> Expect.equal [ num ]
+            ]
+        , test "This is the only test that will get run; the other was skipped!" <|
+            \() ->
+                List.length []
+                    |> Expect.equal 0
+        ]
+-}
+skip : Test -> Test
+skip =
+    Internal.Skipped
 
 
 {-| Options [`fuzzWith`](#fuzzWith) accepts. Currently there is only one but this

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -154,8 +154,11 @@ This functionality is similar to "pending" tests in other frameworks, except
 that a TODO test is considered failing but a pending test often is not.
 -}
 todo : String -> Test
-todo =
-    Internal.Todo
+todo desc =
+    Internal.failNow
+        { description = desc
+        , reason = Test.Expectation.TODO
+        }
 
 
 {-| Returns a [`Test`](#Test) that skips all other tests and only runs the given one.
@@ -256,8 +259,11 @@ fuzzWithHelp options test =
         Internal.Labeled label subTest ->
             Internal.Labeled label (fuzzWithHelp options subTest)
 
-        Internal.Todo _ ->
-            test
+        Internal.Skipped subTest ->
+            -- It's important to treat skipped tests exactly the same as normal,
+            -- until after seed distribution has completed.
+            fuzzWithHelp options subTest
+                |> Internal.Only
 
         Internal.Only subTest ->
             fuzzWithHelp options subTest

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -161,24 +161,25 @@ todo desc =
         }
 
 
-{-| Returns a [`Test`](#Test) that skips all other tests and only runs the given one.
+{-| Returns a [`Test`](#Test) that causes other tests to be skipped, and
+only runs the given one.
 
-These tests aren't meant to be committed to version control. Instead, use them
-when you want to focus on getting a particular subset of your tests to pass.
-If you use `Test.only`, your entire test suite will fail, even if
+Calls to `only` aren't meant to be committed to version control. Instead, use
+them when you want to focus on getting a particular subset of your tests to pass.
+If you use `only`, your entire test suite will fail, even if
 each of the individual tests pass. This is to help avoid accidentally
-committing a `Test.only` to version control.
+committing a `only` to version control.
 
-If you you use `Test.only` on multiple tests, only those tests will run. If you
-put a `Test.only` inside another `Test.only`, only the outermost `Test.only`
+If you you use `only` on multiple tests, only those tests will run. If you
+put a `only` inside another `only`, only the outermost `only`
 will affect which tests gets run.
 
-See also [`Test.skip`](#skip). Note that `skip` takes precedence over `only`;
+See also [`skip`](#skip). Note that `skip` takes precedence over `only`;
 if you use a `skip` inside an `only`, it will still get skipped, and if you use
 an `only` inside a `skip`, it will also get skipped.
 
     describe "List"
-        [ Test.only <| describe "reverse"
+        [ only <| describe "reverse"
             [ test "has no effect on an empty list" <|
                 \() ->
                     List.reverse []
@@ -188,7 +189,7 @@ an `only` inside a `skip`, it will also get skipped.
                      List.reverse [ num ]
                         |> Expect.equal [ num ]
             ]
-        , test "This will not get run, because of the Test.only above!" <|
+        , test "This will not get run, because of the `only` above!" <|
             \() ->
                 List.length []
                     |> Expect.equal 0
@@ -201,19 +202,19 @@ only =
 
 {-| Returns a [`Test`](#Test) that gets skipped.
 
-These tests aren't meant to be committed to version control. Instead, use them
-when you want to focus on getting a particular subset of your tests to pass.
-If you use `Test.skip`, your entire test suite will fail, even if
+Calls to `skip` aren't meant to be committed to version control. Instead, use
+it when you want to focus on getting a particular subset of your tests to
+pass. If you use `skip`, your entire test suite will fail, even if
 each of the individual tests pass. This is to help avoid accidentally
-committing a `Test.skip` to version control.
+committing a `skip` to version control.
 
-See also [`Test.only`](#only). Note that `skip` takes precedence over `only`;
+See also [`only`](#only). Note that `skip` takes precedence over `only`;
 if you use a `skip` inside an `only`, it will still get skipped, and if you use
 an `only` inside a `skip`, it will also get skipped.
 
 
     describe "List"
-        [ Test.skip <| describe "reverse"
+        [ skip <| describe "reverse"
             [ test "has no effect on an empty list" <|
                 \() ->
                     List.reverse []

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -256,6 +256,13 @@ fuzzWithHelp options test =
         Internal.Labeled label subTest ->
             Internal.Labeled label (fuzzWithHelp options subTest)
 
+        Internal.Todo _ ->
+            test
+
+        Internal.Only subTest ->
+            fuzzWithHelp options subTest
+                |> Internal.Only
+
         Internal.Batch tests ->
             tests
                 |> List.map (fuzzWithHelp options)

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -173,7 +173,9 @@ If you you use `Test.only` on multiple tests, only those tests will run. If you
 put a `Test.only` inside another `Test.only`, only the outermost `Test.only`
 will affect which tests gets run.
 
-See also [`Test.skip`](#skip)
+See also [`Test.skip`](#skip). Note that `skip` takes precedence over `only`;
+if you use a `skip` inside an `only`, it will still get skipped, and if you use
+an `only` inside a `skip`, it will also get skipped.
 
     describe "List"
         [ Test.only <| describe "reverse"
@@ -205,7 +207,9 @@ If you use `Test.skip`, your entire test suite will fail, even if
 each of the individual tests pass. This is to help avoid accidentally
 committing a `Test.skip` to version control.
 
-See also [`Test.only`](#only)
+See also [`Test.only`](#only). Note that `skip` takes precedence over `only`;
+if you use a `skip` inside an `only`, it will still get skipped, and if you use
+an `only` inside a `skip`, it will also get skipped.
 
 
     describe "List"

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -8,7 +8,7 @@ import Set exposing (Set)
 type Test
     = Test (Random.Seed -> Int -> List Expectation)
     | Labeled String Test
-    | Todo String
+    | Skipped Test
     | Only Test
     | Batch (List Test)
 
@@ -44,8 +44,8 @@ duplicatedName =
                 Test _ ->
                     []
 
-                Todo str ->
-                    [ str ]
+                Skipped subTest ->
+                    names subTest
 
                 Only subTest ->
                     names subTest

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -1,4 +1,4 @@
-module Test.Internal exposing (Test(..), failNow, filter, duplicatedName, blankDescriptionFailure)
+module Test.Internal exposing (Test(..), failNow, duplicatedName, blankDescriptionFailure)
 
 import Random.Pcg as Random exposing (Generator)
 import Test.Expectation exposing (Expectation(..))
@@ -25,31 +25,6 @@ blankDescriptionFailure =
         { description = "This test has a blank description. Let's give it a useful one!"
         , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
         }
-
-
-filter : (String -> Bool) -> Test -> Test
-filter =
-    filterHelp False
-
-
-filterHelp : Bool -> (String -> Bool) -> Test -> Test
-filterHelp lastCheckPassed isKeepable test =
-    case test of
-        Test _ ->
-            if lastCheckPassed then
-                test
-            else
-                Batch []
-
-        Labeled desc labeledTest ->
-            labeledTest
-                |> filterHelp (isKeepable desc) isKeepable
-                |> Labeled desc
-
-        Batch tests ->
-            tests
-                |> List.map (filterHelp lastCheckPassed isKeepable)
-                |> Batch
 
 
 duplicatedName : List Test -> Result String (Set String)

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -8,6 +8,8 @@ import Set exposing (Set)
 type Test
     = Test (Random.Seed -> Int -> List Expectation)
     | Labeled String Test
+    | Todo String
+    | Only Test
     | Batch (List Test)
 
 
@@ -41,6 +43,12 @@ duplicatedName =
 
                 Test _ ->
                     []
+
+                Todo str ->
+                    [ str ]
+
+                Only subTest ->
+                    names subTest
 
         insertOrFail : String -> Result String (Set String) -> Result String (Set String)
         insertOrFail newName =

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -181,7 +181,7 @@ distributeSeeds runs seed test =
 
         Internal.Todo todo ->
             { seed = seed
-            , runners = { all = [], only = [], todos = [ todo ] }
+            , runners = { all = [], only = [], todos = [ [ todo ] ] }
             }
 
         Internal.Only subTest ->

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -98,7 +98,6 @@ fromTest runs seed test =
                     |> Thunk
                     |> Runnable
                 ]
-            , todos = []
             , only = []
             }
         else
@@ -113,8 +112,7 @@ type alias Distribution =
 
 {-| -}
 type alias SeededRunners =
-    { todos : List (List String)
-    , only : List Runner
+    { only : List Runner
     , all : List Runner
     }
 
@@ -122,7 +120,7 @@ type alias SeededRunners =
 emptyDistribution : Random.Pcg.Seed -> Distribution
 emptyDistribution seed =
     { seed = seed
-    , runners = { all = [], only = [], todos = [] }
+    , runners = { all = [], only = [] }
     }
 
 
@@ -162,7 +160,6 @@ distributeSeeds runs seed test =
                 , runners =
                     { all = [ Runnable (Thunk (\() -> run firstSeed runs)) ]
                     , only = []
-                    , todos = []
                     }
                 }
 
@@ -175,13 +172,12 @@ distributeSeeds runs seed test =
                 , runners =
                     { all = List.map (Labeled description) next.runners.all
                     , only = List.map (Labeled description) next.runners.only
-                    , todos = List.map (\labels -> description :: labels) next.runners.todos
                     }
                 }
 
         Internal.Todo todo ->
             { seed = seed
-            , runners = { all = [], only = [], todos = [ [ todo ] ] }
+            , runners = { all = [], only = [] }
             }
 
         Internal.Only subTest ->
@@ -211,7 +207,6 @@ batchDistribute runs test prev =
         , runners =
             { all = prev.runners.all ++ next.runners.all
             , only = prev.runners.only ++ next.runners.only
-            , todos = prev.runners.todos ++ next.runners.todos
             }
         }
 

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -135,14 +135,15 @@ random number seeds to them. Along the way it also does a few other things:
 
 Some design notes:
 
-1. `only` tests do not affect seed distribution. This is important for the case
-where a user runs tests, sees one failure, and decides to isolate it by using
-both `only` and providing the same seed as before. If `only` changes seed
-distribution, then that test result might not reproduce anymore! This would be
-very frustrating, as it would mean you could reproduce the failure when not
-using `only`, but it magically disappeared as soon as you tried to isolate it.
+1. `only` tests and `skip` tests do not affect seed distribution. This is
+important for the case where a user runs tests, sees one failure, and decides
+to isolate it by using both `only` and providing the same seed as before. If
+`only` changes seed distribution, then that test result might not reproduce!
+This would be very frustrating, as it would mean you could reproduce the
+failure when not using `only`, but it magically disappeared as soon as you
+tried to isolate it. The same logic applies to `skip`.
 
-Theoretically this could become tail-recursive. However, the Labeled and Batch
+2. Theoretically this could become tail-recursive. However, the Labeled and Batch
 cases would presumably become very gnarly, and it's unclear whether there would
 be a performance benefit or penalty in the end. If some brave soul wants to
 attempt it for kicks, beware that this is not a performance optimization for

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -114,7 +114,7 @@ countAllRunnables =
 countRunnables : RunnableTree -> Int
 countRunnables runnable =
     case runnable of
-        Runnable runnable ->
+        Runnable _ ->
             1
 
         Labeled _ runner ->

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -92,16 +92,14 @@ fromTest runs seed test =
                 distributeSeeds runs seed test
         in
             if List.isEmpty distribution.only then
-                case countAllRunnables distribution.skipped of
-                    0 ->
-                        distribution.all
-                            |> List.concatMap fromRunnableTree
-                            |> Plain
-
-                    skipped ->
-                        distribution.all
-                            |> List.concatMap fromRunnableTree
-                            |> Skipping skipped
+                if countAllRunnables distribution.skipped == 0 then
+                    distribution.all
+                        |> List.concatMap fromRunnableTree
+                        |> Plain
+                else
+                    distribution.all
+                        |> List.concatMap fromRunnableTree
+                        |> Skipping
             else
                 distribution.only
                     |> List.concatMap fromRunnableTree
@@ -164,7 +162,7 @@ type alias Distribution =
 type SeededRunners
     = Plain (List Runner)
     | Only (List Runner)
-    | Skipping Int (List Runner)
+    | Skipping (List Runner)
     | Invalid String
 
 

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -73,6 +73,13 @@ expectFailureHelper f test =
         TI.Batch tests ->
             TI.Batch (List.map (expectFailureHelper f) tests)
 
+        TI.Todo _ ->
+            test
+
+        TI.Only subTest ->
+            expectFailureHelper f subTest
+                |> TI.Only
+
 
 testShrinking : Test -> Test
 testShrinking =

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -73,8 +73,9 @@ expectFailureHelper f test =
         TI.Batch tests ->
             TI.Batch (List.map (expectFailureHelper f) tests)
 
-        TI.Todo _ ->
-            test
+        TI.Skipped subTest ->
+            expectFailureHelper f subTest
+                |> TI.Skipped
 
         TI.Only subTest ->
             expectFailureHelper f subTest

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -1,4 +1,4 @@
-module Helpers exposing (passingTest, testStringLengthIsPreserved, expectToFail, testShrinking, randomSeedFuzzer, succeeded)
+module Helpers exposing (expectPass, testStringLengthIsPreserved, expectToFail, testShrinking, randomSeedFuzzer, succeeded)
 
 import Test exposing (Test)
 import Test.Expectation exposing (Expectation(..))
@@ -10,8 +10,8 @@ import Random.Pcg as Random
 import Shrink
 
 
-passingTest : a -> Expectation
-passingTest _ =
+expectPass : a -> Expectation
+expectPass _ =
     Expect.pass
 
 

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -8,15 +8,15 @@ Note that this always uses an initial seed of 902101337, since it can't do effec
 -}
 
 import Runner.Log
-import Html
+import Platform
 import Tests
 
 
 main : Program Never () msg
 main =
-    Html.beginnerProgram
-        { model = ()
-        , update = \_ _ -> ()
-        , view = \() -> Html.text "Check the console for useful output!"
+    Platform.program
+        { init = ( (), Cmd.none )
+        , update = \_ _ -> ( (), Cmd.none )
+        , subscriptions = \_ -> Sub.none
         }
         |> Runner.Log.run Tests.all

--- a/tests/Runner/Log.elm
+++ b/tests/Runner/Log.elm
@@ -40,13 +40,18 @@ runWithOptions runs seed test =
 
 
 summarize : Summary -> String
-summarize { output, passed, failed } =
+summarize { output, passed, failed, autoFail } =
     let
         headline =
             if failed > 0 then
                 output ++ "\n\nTEST RUN FAILED"
             else
-                "TEST RUN PASSED"
+                case autoFail of
+                    Nothing ->
+                        "TEST RUN PASSED"
+
+                    Just reason ->
+                        "TEST RUN FAILED because " ++ reason
     in
         String.join "\n"
             [ output
@@ -63,7 +68,7 @@ logOutput summary arg =
             summarize summary ++ "\n\nExit code"
 
         _ =
-            if summary.failed > 0 then
+            if summary.failed > 0 || summary.autoFail /= Nothing then
                 output
                     |> (flip Debug.log 1)
                     |> (\_ -> Debug.crash "FAILED TEST RUN")

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -25,7 +25,7 @@ type alias Summary =
 
 toOutput : Summary -> SeededRunners -> Summary
 toOutput summary seededRunners =
-    List.foldl (toOutputHelp []) summary seededRunners.all
+    List.foldl (toOutputHelp []) summary seededRunners.runners
 
 
 toOutputHelp : List String -> Runner -> Summary -> Summary

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -38,6 +38,9 @@ toOutputHelp labels runner summary =
         Labeled label subRunner ->
             toOutputHelp (label :: labels) subRunner summary
 
+        Skipped _ ->
+            summary
+
         Batch runners ->
             List.foldl (toOutputHelp labels) summary runners
 

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -13,7 +13,7 @@ Note that this always uses an initial seed of 902101337, since it can't do effec
 import Expect exposing (Expectation)
 import Random.Pcg as Random
 import Test exposing (Test)
-import Test.Runner exposing (Runner(..), SeededRunners(..))
+import Test.Runner exposing (Runner, SeededRunners(..))
 
 
 {-| The output string, the number of passed tests,
@@ -36,7 +36,7 @@ toOutput summary seededRunners =
             Only runners ->
                 render runners
 
-            Skipping skipped runners ->
+            Skipping runners ->
                 render runners
 
             Invalid message ->
@@ -45,16 +45,8 @@ toOutput summary seededRunners =
 
 toOutputHelp : List String -> Runner -> Summary -> Summary
 toOutputHelp labels runner summary =
-    case runner of
-        Runnable runnable ->
-            Test.Runner.run runnable
-                |> List.foldl fromExpectation summary
-
-        Labeled label subRunner ->
-            toOutputHelp (label :: labels) subRunner summary
-
-        Batch runners ->
-            List.foldl (toOutputHelp labels) summary runners
+    runner.run ()
+        |> List.foldl fromExpectation summary
 
 
 fromExpectation : Expectation -> Summary -> Summary

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -38,9 +38,6 @@ toOutputHelp labels runner summary =
         Labeled label subRunner ->
             toOutputHelp (label :: labels) subRunner summary
 
-        Skipped _ ->
-            summary
-
         Batch runners ->
             List.foldl (toOutputHelp labels) summary runners
 

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -20,27 +20,27 @@ import Test.Runner exposing (Runner, SeededRunners(..))
 and the number of failed tests.
 -}
 type alias Summary =
-    { output : String, passed : Int, failed : Int }
+    { output : String, passed : Int, failed : Int, autoFail : Maybe String }
 
 
 toOutput : Summary -> SeededRunners -> Summary
 toOutput summary seededRunners =
     let
         render =
-            List.foldl (toOutputHelp []) summary
+            List.foldl (toOutputHelp [])
     in
         case seededRunners of
             Plain runners ->
-                render runners
+                render { summary | autoFail = Nothing } runners
 
             Only runners ->
-                render runners
+                render { summary | autoFail = Just "Test.only was used" } runners
 
             Skipping runners ->
-                render runners
+                render { summary | autoFail = Just "Test.skip was used" } runners
 
             Invalid message ->
-                { output = message, passed = 0, failed = 0 }
+                { output = message, passed = 0, failed = 0, autoFail = Nothing }
 
 
 toOutputHelp : List String -> Runner -> Summary -> Summary
@@ -123,5 +123,6 @@ runWithOptions runs seed test =
             { output = ""
             , passed = 0
             , failed = 0
+            , autoFail = Just "no tests were run"
             }
             seededRunners

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -20,25 +20,12 @@ import Test.Runner exposing (Runner(..), SeededRunners)
 and the number of failed tests.
 -}
 type alias Summary =
-    { output : String, passed : Int, failed : Int, todos : List (List String) }
+    { output : String, passed : Int, failed : Int }
 
 
 toOutput : Summary -> SeededRunners -> Summary
 toOutput summary seededRunners =
-    let
-        result =
-            List.foldl (toOutputHelp []) summary seededRunners.all
-    in
-        { result
-            | output = result.output ++ outputTodos result.todos
-        }
-
-
-outputTodos : List (List String) -> String
-outputTodos todos =
-    todos
-        |> List.map outputLabels
-        |> String.join "\n\n"
+    List.foldl (toOutputHelp []) summary seededRunners.all
 
 
 toOutputHelp : List String -> Runner -> Summary -> Summary
@@ -129,6 +116,5 @@ runWithOptions runs seed test =
             { output = ""
             , passed = 0
             , failed = 0
-            , todos = seededRunners.todos
             }
             seededRunners

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -13,7 +13,7 @@ Note that this always uses an initial seed of 902101337, since it can't do effec
 import Expect exposing (Expectation)
 import Random.Pcg as Random
 import Test exposing (Test)
-import Test.Runner exposing (Runner(..), SeededRunners)
+import Test.Runner exposing (Runner(..), SeededRunners(..))
 
 
 {-| The output string, the number of passed tests,
@@ -25,7 +25,22 @@ type alias Summary =
 
 toOutput : Summary -> SeededRunners -> Summary
 toOutput summary seededRunners =
-    List.foldl (toOutputHelp []) summary seededRunners.runners
+    let
+        render =
+            List.foldl (toOutputHelp []) summary
+    in
+        case seededRunners of
+            Plain runners ->
+                render runners
+
+            Only runners ->
+                render runners
+
+            Skipping skipped runners ->
+                render runners
+
+            Invalid message ->
+                { output = message, passed = 0, failed = 0 }
 
 
 toOutputHelp : List String -> Runner -> Summary -> Summary

--- a/tests/RunnerTests.elm
+++ b/tests/RunnerTests.elm
@@ -5,6 +5,7 @@ import Fuzz exposing (..)
 import Test exposing (..)
 import Test.Runner exposing (SeededRunners(..))
 import Random.Pcg as Random
+import Helpers exposing (expectPass)
 
 
 all : Test
@@ -42,8 +43,7 @@ fromTest =
                         runners =
                             toSeededRunners <|
                                 describe "three tests"
-                                    [ test "passes" <|
-                                        \() -> Expect.pass
+                                    [ test "passes" expectPass
                                     , Test.only <|
                                         describe "two tests"
                                             [ test "fails" <|
@@ -68,8 +68,7 @@ fromTest =
                         runners =
                             toSeededRunners <|
                                 describe "three tests"
-                                    [ test "passes" <|
-                                        \() -> Expect.pass
+                                    [ test "passes" expectPass
                                     , Test.only <|
                                         describe "two tests"
                                             [ test "fails" <|
@@ -94,8 +93,7 @@ fromTest =
                         runners =
                             toSeededRunners <|
                                 describe "three tests"
-                                    [ test "passes" <|
-                                        \() -> Expect.pass
+                                    [ test "passes" expectPass
                                     , Test.skip <|
                                         describe "two tests"
                                             [ test "fails" <|
@@ -116,7 +114,7 @@ fromTest =
                                 Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ toString val)
             , test "a test that uses only is an Only summary" <|
                 \() ->
-                    case toSeededRunners (Test.only <| test "passes" (\() -> Expect.pass)) of
+                    case toSeededRunners (Test.only <| test "passes" expectPass) of
                         Only runners ->
                             runners
                                 |> List.length
@@ -130,8 +128,7 @@ fromTest =
                         runners =
                             toSeededRunners <|
                                 describe "three tests"
-                                    [ test "passes" <|
-                                        \() -> Expect.pass
+                                    [ test "passes" expectPass
                                     , Test.skip <|
                                         describe "two tests"
                                             [ test "fails" <|
@@ -156,8 +153,7 @@ fromTest =
                         runners =
                             toSeededRunners <|
                                 describe "two tests"
-                                    [ test "passes" <|
-                                        \() -> Expect.pass
+                                    [ test "passes" expectPass
                                     , Test.skip <|
                                         test "fails" <|
                                             \() -> Expect.fail "failed on purpose"
@@ -173,7 +169,7 @@ fromTest =
                                 Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ toString val)
             , test "when all tests are skipped, we get an empty Skipping summary" <|
                 \() ->
-                    case toSeededRunners (Test.skip <| test "passes" (\() -> Expect.pass)) of
+                    case toSeededRunners (Test.skip <| test "passes" expectPass) of
                         Skipping runners ->
                             runners
                                 |> List.length
@@ -183,7 +179,7 @@ fromTest =
                             Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ toString val)
             , test "a test that does not use only or skip is a Plain summary" <|
                 \() ->
-                    case toSeededRunners (test "passes" (\() -> Expect.pass)) of
+                    case toSeededRunners (test "passes" expectPass) of
                         Plain runners ->
                             runners
                                 |> List.length
@@ -197,4 +193,4 @@ fromTest =
 
 passing : Test
 passing =
-    test "A passing test" (\() -> Expect.pass)
+    test "A passing test" expectPass

--- a/tests/RunnerTests.elm
+++ b/tests/RunnerTests.elm
@@ -1,4 +1,4 @@
-module Test.Runner.Tests exposing (all)
+module RunnerTests exposing (all)
 
 import Expect
 import Fuzz exposing (..)

--- a/tests/Test/Runner/Tests.elm
+++ b/tests/Test/Runner/Tests.elm
@@ -21,35 +21,45 @@ toSeededRunners =
 fromTest : Test
 fromTest =
     describe "TestRunner.fromTest"
-        [ Test.skip <|
-            describe "test length"
-                [ fuzz2 int int "only positive tests runs are valid" <|
-                    \runs intSeed ->
-                        case Test.Runner.fromTest runs (Random.initialSeed intSeed) passing of
-                            Invalid str ->
-                                if runs > 0 then
-                                    Expect.fail ("Expected a run count of " ++ toString runs ++ " to be valid, but was invalid with this message: " ++ toString str)
-                                else
-                                    Expect.pass
+        [ describe "test length"
+            [ fuzz2 int int "only positive tests runs are valid" <|
+                \runs intSeed ->
+                    case Test.Runner.fromTest runs (Random.initialSeed intSeed) passing of
+                        Invalid str ->
+                            if runs > 0 then
+                                Expect.fail ("Expected a run count of " ++ toString runs ++ " to be valid, but was invalid with this message: " ++ toString str)
+                            else
+                                Expect.pass
 
-                            val ->
-                                if runs > 0 then
-                                    Expect.pass
-                                else
-                                    Expect.fail ("Expected a run count of " ++ toString runs ++ " to be invalid, but was valid with this value: " ++ toString val)
-                , test "a test that uses only is an Only summary" <|
-                    \() ->
-                        case toSeededRunners (Test.only <| test "passes" (\() -> Expect.pass)) of
-                            Only runners ->
-                                runners
-                                    |> List.length
-                                    |> Expect.equal 1
+                        val ->
+                            if runs > 0 then
+                                Expect.pass
+                            else
+                                Expect.fail ("Expected a run count of " ++ toString runs ++ " to be invalid, but was valid with this value: " ++ toString val)
+            , test "a test that uses only is an Only summary" <|
+                \() ->
+                    case toSeededRunners (Test.only <| test "passes" (\() -> Expect.pass)) of
+                        Only runners ->
+                            runners
+                                |> List.length
+                                |> Expect.equal 1
 
-                            val ->
-                                Expect.fail ("Expected SeededRunner to be Only, but was " ++ toString val)
-                , test "a test that uses skip is a Skipping summary" <|
-                    \() ->
-                        case toSeededRunners (Test.skip <| test "passes" (\() -> Expect.pass)) of
+                        val ->
+                            Expect.fail ("Expected SeededRunner to be Only, but was " ++ toString val)
+            , test "a pair of tests where one uses skip is a Skipping summary" <|
+                \() ->
+                    let
+                        runners =
+                            toSeededRunners <|
+                                describe "two tests"
+                                    [ test "passes" <|
+                                        \() -> Expect.pass
+                                    , Test.skip <|
+                                        test "fails" <|
+                                            \() -> Expect.fail "failed on purpose"
+                                    ]
+                    in
+                        case runners of
                             Skipping runners ->
                                 runners
                                     |> List.length
@@ -57,17 +67,27 @@ fromTest =
 
                             val ->
                                 Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ toString val)
-                , test "a test that does not use only or skip is a Plain summary" <|
-                    \() ->
-                        case toSeededRunners (test "passes" (\() -> Expect.pass)) of
-                            Plain runners ->
-                                runners
-                                    |> List.length
-                                    |> Expect.equal 1
+            , test "a test that uses skip is an empty Skipping summary" <|
+                \() ->
+                    case toSeededRunners (Test.skip <| test "passes" (\() -> Expect.pass)) of
+                        Skipping runners ->
+                            runners
+                                |> List.length
+                                |> Expect.equal 0
 
-                            val ->
-                                Expect.fail ("Expected SeededRunner to be Plain, but was " ++ toString val)
-                ]
+                        val ->
+                            Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ toString val)
+            , test "a test that does not use only or skip is a Plain summary" <|
+                \() ->
+                    case toSeededRunners (test "passes" (\() -> Expect.pass)) of
+                        Plain runners ->
+                            runners
+                                |> List.length
+                                |> Expect.equal 1
+
+                        val ->
+                            Expect.fail ("Expected SeededRunner to be Plain, but was " ++ toString val)
+            ]
         ]
 
 

--- a/tests/Test/Runner/Tests.elm
+++ b/tests/Test/Runner/Tests.elm
@@ -1,0 +1,96 @@
+module Test.Runner.Tests exposing (all)
+
+import Expect
+import Fuzz exposing (..)
+import Test exposing (..)
+import Test.Runner exposing (SeededRunners(..))
+import Random.Pcg as Random
+
+
+all : Test
+all =
+    Test.concat
+        [ fromTest ]
+
+
+
+-- fromTest : Int -> Random.Pcg.Seed -> Test -> SeededRunners
+-- fromTest runs seed test =
+
+
+toSeededRunners : Test -> SeededRunners
+toSeededRunners =
+    Test.Runner.fromTest 5 (Random.initialSeed 42)
+
+
+fromTest : Test
+fromTest =
+    describe "TestRunner.fromTest"
+        [ Test.skip <|
+            describe "test length"
+                [ fuzz2 int int "only positive tests runs are valid" <|
+                    \runs intSeed ->
+                        case Test.Runner.fromTest runs (Random.initialSeed intSeed) passing of
+                            Invalid str ->
+                                if runs > 0 then
+                                    Expect.fail ("Expected a run count of " ++ toString runs ++ " to be valid, but was invalid with this message: " ++ toString str)
+                                else
+                                    Expect.pass
+
+                            val ->
+                                if runs > 0 then
+                                    Expect.pass
+                                else
+                                    Expect.fail ("Expected a run count of " ++ toString runs ++ " to be invalid, but was valid with this value: " ++ toString val)
+                , test "a test that uses only is an Only summary" <|
+                    \() ->
+                        case toSeededRunners (Test.only <| test "passes" (\() -> Expect.pass)) of
+                            Only runners ->
+                                runners
+                                    |> List.length
+                                    |> Expect.equal 1
+
+                            val ->
+                                Expect.fail ("Expected SeededRunner to be Only, but was " ++ toString val)
+                , test "a test that uses skip is a Skipping summary" <|
+                    \() ->
+                        case toSeededRunners (Test.skip <| test "passes" (\() -> Expect.pass)) of
+                            Skipping runners ->
+                                runners
+                                    |> List.length
+                                    |> Expect.equal 1
+
+                            val ->
+                                Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ toString val)
+                , test "a test that does not use only or skip is a Plain summary" <|
+                    \() ->
+                        case toSeededRunners (test "passes" (\() -> Expect.pass)) of
+                            Plain runners ->
+                                runners
+                                    |> List.length
+                                    |> Expect.equal 1
+
+                            val ->
+                                Expect.fail ("Expected SeededRunner to be Plain, but was " ++ toString val)
+                ]
+        ]
+
+
+passing : Test
+passing =
+    test "A passing test" (\() -> Expect.pass)
+
+
+
+--
+-- type SeededRunners
+--     = Plain (List Runner)
+--     | Only (List Runner)
+--     | Skipping (List Runner)
+--     | Invalid String
+--
+--
+-- type alias Runner =
+--     { run : () -> List Expectation
+--     , labels : List String
+--     }

--- a/tests/Test/Runner/Tests.elm
+++ b/tests/Test/Runner/Tests.elm
@@ -13,11 +13,6 @@ all =
         [ fromTest ]
 
 
-
--- fromTest : Int -> Random.Pcg.Seed -> Test -> SeededRunners
--- fromTest runs seed test =
-
-
 toSeededRunners : Test -> SeededRunners
 toSeededRunners =
     Test.Runner.fromTest 5 (Random.initialSeed 42)
@@ -79,18 +74,3 @@ fromTest =
 passing : Test
 passing =
     test "A passing test" (\() -> Expect.pass)
-
-
-
---
--- type SeededRunners
---     = Plain (List Runner)
---     | Only (List Runner)
---     | Skipping (List Runner)
---     | Invalid String
---
---
--- type alias Runner =
---     { run : () -> List Expectation
---     , labels : List String
---     }

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -99,17 +99,17 @@ testTests =
     describe "functions that create tests"
         [ describe "describe"
             [ expectToFail <| describe "fails with empty list" []
-            , expectToFail <| describe "" [ test "describe with empty description fail" <| passingTest ]
+            , expectToFail <| describe "" [ test "describe with empty description fail" expectPass ]
             ]
         , describe "test"
-            [ expectToFail <| test "" passingTest
+            [ expectToFail <| test "" expectPass
             ]
         , describe "fuzz"
-            [ expectToFail <| fuzz Fuzz.bool "" passingTest
+            [ expectToFail <| fuzz Fuzz.bool "" expectPass
             ]
         , describe "fuzzWith"
-            [ expectToFail <| fuzzWith { runs = 0 } Fuzz.bool "nonpositive" passingTest
-            , expectToFail <| fuzzWith { runs = 1 } Fuzz.bool "" passingTest
+            [ expectToFail <| fuzzWith { runs = 0 } Fuzz.bool "nonpositive" expectPass
+            , expectToFail <| fuzzWith { runs = 1 } Fuzz.bool "" expectPass
             ]
         , describe "Test.todo"
             [ expectToFail <| todo "a TODO test fails"
@@ -133,43 +133,43 @@ identicalNamesAreRejectedTests =
     describe "Identically-named sibling and parent/child tests fail"
         [ expectToFail <|
             describe "a describe with two identically named children fails"
-                [ test "foo" passingTest
-                , test "foo" passingTest
+                [ test "foo" expectPass
+                , test "foo" expectPass
                 ]
         , expectToFail <|
             describe "a describe with the same name as a child test fails"
-                [ test "a describe with the same name as a child test fails" passingTest
+                [ test "a describe with the same name as a child test fails" expectPass
                 ]
         , expectToFail <|
             describe "a describe with the same name as a child describe fails"
                 [ describe "a describe with the same name as a child describe fails"
-                    [ test "a test" passingTest ]
+                    [ test "a test" expectPass ]
                 ]
         , expectToFail <|
             Test.concat
                 [ describe "a describe with the same name as a sibling describe fails"
-                    [ test "a test" passingTest ]
+                    [ test "a test" expectPass ]
                 , describe "a describe with the same name as a sibling describe fails"
-                    [ test "another test" passingTest ]
+                    [ test "another test" expectPass ]
                 ]
         , expectToFail <|
             Test.concat
                 [ Test.concat
                     [ describe "a describe with the same name as a de facto sibling describe fails"
-                        [ test "a test" passingTest ]
+                        [ test "a test" expectPass ]
                     ]
                 , describe "a describe with the same name as a de facto sibling describe fails"
-                    [ test "another test" passingTest ]
+                    [ test "another test" expectPass ]
                 ]
         , expectToFail <|
             Test.concat
                 [ Test.concat
                     [ describe "a describe with the same name as a de facto sibling describe fails"
-                        [ test "a test" passingTest ]
+                        [ test "a test" expectPass ]
                     ]
                 , Test.concat
                     [ describe "a describe with the same name as a de facto sibling describe fails"
-                        [ test "another test" passingTest ]
+                        [ test "another test" expectPass ]
                     ]
                 ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -10,12 +10,19 @@ import Expect
 import Helpers exposing (..)
 import ExpectWithinTests exposing (testExpectWithin)
 import FuzzerTests exposing (fuzzerTests)
+import Test.Runner.Tests
 
 
 all : Test
 all =
     Test.concat
-        [ readmeExample, regressions, testTests, expectationTests, fuzzerTests ]
+        [ readmeExample
+        , regressions
+        , testTests
+        , expectationTests
+        , fuzzerTests
+        , Test.Runner.Tests.all
+        ]
 
 
 readmeExample : Test

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -10,7 +10,7 @@ import Expect
 import Helpers exposing (..)
 import ExpectWithinTests exposing (testExpectWithin)
 import FuzzerTests exposing (fuzzerTests)
-import Test.Runner.Tests
+import RunnerTests
 
 
 all : Test
@@ -21,7 +21,7 @@ all =
         , testTests
         , expectationTests
         , fuzzerTests
-        , Test.Runner.Tests.all
+        , RunnerTests.all
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -74,8 +74,6 @@ expectationTests =
                     \_ -> "dummy subject" |> Expect.all []
             ]
         , testExpectWithin
-
-        -- , describe "Expect.somethingElse" [ ... ]
         ]
 
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,7 +12,6 @@
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
Completes https://github.com/elm-community/elm-test/issues/142

Replaces `Test.filter` with `Test.only` and `Test.skip`

I ended up going with the `only`/`skip` algorithm that is [easier to explain](https://github.com/elm-community/elm-test/issues/142#issuecomment-288862880). I think this is the right choice for the initial release of the feature, because:

1) it's a bit easier to learn (although I agree that the alternative is [not super hard](https://github.com/elm-community/elm-test/issues/142#issuecomment-288981351))
2) if it turns out there's significant demand for the other way in practice, it's easier to go from "`only` inside `only` does nothing" to "`only` inside `only`now does something" than it is to go the other way around
3) releasing this way will give us more data on demand for the alternative in practice, which would better justify imposing the learning cost of the other algorithm