### PR TITLE
Removing Fuzz.andThen

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -1,4 +1,4 @@
-module Fuzz exposing (Fuzzer, andMap, andThen, array, bool, char, conditional, constant, custom, float, floatRange, frequency, int, intRange, invalid, list, map, map2, map3, map4, map5, maybe, oneOf, order, percentage, result, string, tuple, tuple3, tuple4, tuple5, unit)
+module Fuzz exposing (Fuzzer, andMap, array, bool, char, conditional, constant, custom, float, floatRange, frequency, int, intRange, invalid, list, map, map2, map3, map4, map5, maybe, oneOf, order, percentage, result, string, tuple, tuple3, tuple4, tuple5, unit)
 
 {-| This is a library of _fuzzers_ you can use to supply values to your fuzz
 tests. You can typically pick out which ones you need according to their types.
@@ -19,8 +19,7 @@ reproduces a bug.
 
 ## Working with Fuzzers
 
-@docs Fuzzer, constant, map, map2, map3, map4, map5, andMap, andThen, frequency, conditional
-@docs Fuzzer, oneOf, constant, map, map2, map3, map4, map5, andMap, andThen, frequency, conditional
+@docs Fuzzer, oneOf, constant, map, map2, map3, map4, map5, andMap, frequency, conditional
 
 
 ## Tuple Fuzzers
@@ -494,13 +493,6 @@ Note that shrinking may be better using mapN.
 andMap : Fuzzer a -> Fuzzer (a -> b) -> Fuzzer b
 andMap =
     map2 (|>)
-
-
-{-| Create a fuzzer based on the result of another fuzzer.
--}
-andThen : (a -> Fuzzer b) -> Fuzzer a -> Fuzzer b
-andThen =
-    Internal.andThen
 
 
 {-| Conditionally filter a fuzzer to remove occasional undesirable

--- a/src/Fuzz/Internal.elm
+++ b/src/Fuzz/Internal.elm
@@ -1,4 +1,4 @@
-module Fuzz.Internal exposing (Fuzzer(Fuzzer), Valid, ValidFuzzer, combineValid, invalidReason, map)
+module Fuzz.Internal exposing (Fuzzer(Fuzzer), Valid, ValidFuzzer)
 
 import Random.Pcg as Random exposing (Generator)
 import RoseTree exposing (RoseTree(Rose))
@@ -14,32 +14,3 @@ type alias Valid a =
 
 type alias ValidFuzzer a =
     Generator (RoseTree a)
-
-
-combineValid : List (Valid a) -> Valid (List a)
-combineValid valids =
-    case valids of
-        [] ->
-            Ok []
-
-        (Ok x) :: rest ->
-            Result.map ((::) x) (combineValid rest)
-
-        (Err reason) :: _ ->
-            Err reason
-
-
-map : (a -> b) -> Fuzzer a -> Fuzzer b
-map fn (Fuzzer fuzzer) =
-    (Result.map << Random.map << RoseTree.map) fn fuzzer
-        |> Fuzzer
-
-
-invalidReason : Valid a -> Maybe String
-invalidReason valid =
-    case valid of
-        Ok _ ->
-            Nothing
-
-        Err reason ->
-            Just reason

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -1,8 +1,7 @@
 module Test.Fuzz exposing (fuzzTest)
 
 import Dict exposing (Dict)
-import Fuzz exposing (Fuzzer)
-import Fuzz.Internal exposing (ValidFuzzer)
+import Fuzz.Internal exposing (Fuzzer(Fuzzer), ValidFuzzer)
 import Lazy.List
 import Random.Pcg as Random exposing (Generator)
 import RoseTree exposing (RoseTree(..))
@@ -13,7 +12,7 @@ import Test.Internal exposing (Test(..), blankDescriptionFailure, failNow)
 {-| Reject always-failing tests because of bad names or invalid fuzzers.
 -}
 fuzzTest : Fuzzer a -> String -> (a -> Expectation) -> Test
-fuzzTest fuzzer untrimmedDesc getExpectation =
+fuzzTest (Fuzzer fuzzer) untrimmedDesc getExpectation =
     let
         desc =
             String.trim untrimmedDesc

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -42,6 +42,7 @@ These functions give you the ability to run fuzzers separate of running fuzz tes
 
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer)
+import Fuzz.Internal as FuzzInternal
 import Lazy.List as LazyList exposing (LazyList)
 import Random.Pcg
 import RoseTree exposing (RoseTree(Rose))
@@ -374,7 +375,7 @@ type Shrinkable a
 Shrinkable. The value is what a fuzz test would have received as input.
 -}
 fuzz : Fuzzer a -> Random.Pcg.Generator ( a, Shrinkable a )
-fuzz fuzzer =
+fuzz (FuzzInternal.Fuzzer fuzzer) =
     case fuzzer of
         Ok validFuzzer ->
             validFuzzer

--- a/tests/FuzzerTests.elm
+++ b/tests/FuzzerTests.elm
@@ -49,9 +49,6 @@ fuzzerTests =
             "Fuzz.frequency"
             (Expect.greaterThan 0)
         , fuzz (result string int) "Fuzz.result" <| \r -> Expect.pass
-        , fuzz (andThen (\i -> intRange 0 (2 ^ i)) (intRange 1 8))
-            "Fuzz.andThen"
-            (Expect.atMost 256)
         , fuzz
             (map2 (,) die die
                 |> conditional
@@ -178,9 +175,6 @@ shrinkingTests =
                                     True
                     in
                         checkPair aList |> Expect.true "[1,0]|[0,-1]"
-            , fuzz (intRange 1 8 |> andThen (\i -> intRange 0 (2 ^ i))) "Fuzz.andThen shrinks a number" <|
-                \i ->
-                    i <= 2 |> Expect.true "3"
             ]
 
 

--- a/tests/FuzzerTests.elm
+++ b/tests/FuzzerTests.elm
@@ -1,5 +1,6 @@
 module FuzzerTests exposing (fuzzerTests)
 
+import Fuzz.Internal as Internal
 import Expect
 import Fuzz exposing (..)
 import Helpers exposing (..)
@@ -98,7 +99,7 @@ fuzzerTests =
                                 else
                                     Expect.fail <| "Shrunken value does not pass conditional: " ++ toString value
                 in
-                testShrinkable shrinkable
+                    testShrinkable shrinkable
         , describe "Whitebox testing using Fuzz.Internal"
             [ fuzz randomSeedFuzzer "the same value is generated with and without shrinking" <|
                 \seed ->
@@ -106,7 +107,7 @@ fuzzerTests =
                         step gen =
                             Random.step gen seed
 
-                        aFuzzer =
+                        (Internal.Fuzzer aFuzzer) =
                             tuple5
                                 ( tuple ( list int, array float )
                                 , maybe bool
@@ -125,7 +126,7 @@ fuzzerTests =
                         valWithShrink =
                             aFuzzer |> Result.map (step >> Tuple.first >> RoseTree.root)
                     in
-                    Expect.equal valNoShrink valWithShrink
+                        Expect.equal valNoShrink valWithShrink
             , shrinkingTests
             , manualFuzzerTests
             ]
@@ -176,7 +177,7 @@ shrinkingTests =
                                 _ ->
                                     True
                     in
-                    checkPair aList |> Expect.true "[1,0]|[0,-1]"
+                        checkPair aList |> Expect.true "[1,0]|[0,-1]"
             , fuzz (intRange 1 8 |> andThen (\i -> intRange 0 (2 ^ i))) "Fuzz.andThen shrinks a number" <|
                 \i ->
                     i <= 2 |> Expect.true "3"
@@ -219,14 +220,14 @@ manualFuzzerTests =
                             Nothing ->
                                 acc
                 in
-                unfold [] pair
-                    |> Expect.all
-                        [ List.all failsTest >> Expect.true "Not all elements were even"
-                        , List.head
-                            >> Maybe.map (Expect.all [ Expect.lessThan 5, Expect.atLeast 0 ])
-                            >> Maybe.withDefault (Expect.fail "Did not cause failure")
-                        , List.reverse >> List.head >> Expect.equal (Maybe.map Tuple.first pair)
-                        ]
+                    unfold [] pair
+                        |> Expect.all
+                            [ List.all failsTest >> Expect.true "Not all elements were even"
+                            , List.head
+                                >> Maybe.map (Expect.all [ Expect.lessThan 5, Expect.atLeast 0 ])
+                                >> Maybe.withDefault (Expect.fail "Did not cause failure")
+                            , List.reverse >> List.head >> Expect.equal (Maybe.map Tuple.first pair)
+                            ]
         , fuzz randomSeedFuzzer "No strings contain the letter e" <|
             \seed ->
                 let
@@ -253,10 +254,10 @@ manualFuzzerTests =
                             Nothing ->
                                 acc
                 in
-                unfold [] pair
-                    |> Expect.all
-                        [ List.all failsTest >> Expect.true "Not all contained the letter e"
-                        , List.head >> Expect.equal (Just "e")
-                        , List.reverse >> List.head >> Expect.equal (Maybe.map Tuple.first pair)
-                        ]
+                    unfold [] pair
+                        |> Expect.all
+                            [ List.all failsTest >> Expect.true "Not all contained the letter e"
+                            , List.head >> Expect.equal (Just "e")
+                            , List.reverse >> List.head >> Expect.equal (Maybe.map Tuple.first pair)
+                            ]
         ]


### PR DESCRIPTION
Resolves #161.

This removes Fuzz.andThen making it a breaking change.
It also fixes two points @mgold alluded to before:
- the `Fuzzer` type is wrapped in a type instead of being a type alias to prevent people from casing on it. This is not a major change according to `elm-package` but it is if to user who for some reason is casing on the fuzzer now, so it makes sense to me to bundle the change in here.
- Move the last two functions in `Fuzz.Internal` over to `Fuzz`.

Some things I think should be wrapped up before merging this:
- [ ] Make solutions for users using `andThen` for building recusive fuzzers or `Msg` fuzzers presentable, either by publishing them in a library or linking to them as a sort of cookbook.
- [ ] Consider if there's other breaking changes that should be bundled with this change. Personally, I'd like to change `Test.Runner.fuzz` so it doesn't need a `Debug.crash` anymore (the last in the codebase).