### PR TITLE
Use pure elm for laziness

### DIFF
--- a/benchmarks/elm-package.json
+++ b/benchmarks/elm-package.json
@@ -10,11 +10,11 @@
     "exposed-modules": [],
     "dependencies": {
         "BrianHicks/elm-benchmark": "1.0.2 <= v < 2.0.0",
-        "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
-        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-lazy-list": "1.0.0 <= v < 2.0.0",
+        "eeue56/elm-shrink": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "elm-lang/lazy": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-lazy": "1.0.0 <= v < 2.0.0",
         "mgold/elm-random-pcg": "5.0.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/elm-package.json
+++ b/elm-package.json
@@ -13,10 +13,10 @@
         "Fuzz"
     ],
     "dependencies": {
-        "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
-        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-lazy-list": "1.0.0 <= v < 2.0.0",
+        "eeue56/elm-shrink": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/lazy": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-lazy": "1.0.0 <= v < 2.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,10 +9,10 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
-        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-lazy-list": "1.0.0 <= v < 2.0.0",
+        "eeue56/elm-shrink": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/lazy": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-lazy": "1.0.0 <= v < 2.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
## What

This PR does a few things:
- switch lazy to be a version written in pure Elm, which only does lazy evaluation (no implicit memoization)
- switch lazy-list to use Elm lazy package
- switch shrink to use Elm lazy package
- switch elm-test to use pure Elm laziness
- update the tests to work with the latest runner

## Why

In theory, I believe that memoization is actually harmful to large test suites with in terms of memory and performance as a result. As elm-test only visits each node once, there is no need for memoization. I discussed this with @mgold on Slack, who confirmed that this theory could be accurate.

## What needs to happen before merging?

I need people to run the benchmarks! As we can't currently run elm-benchmark on node, it would be very useful to have some information on how the benchmarks perform in different browsers (and therefore different GC techniques). My first comment after this PR will be the results that I got, which showed an improvement across the board for the pure-Elm version.

To test:

- open `benchmarks/new.html` in a browser
- open `benchmarks/old.html` in a browser

## Future changes

The initial gain over the old approach is decent, but not by a magnitude. If we can confirm that this approach is faster, then there are a couple of optimizations I can do to further improve these results.

