### PR TITLE
Fix "skip" example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ wipSuite =
         [ only <| describe "Marking this test as `only` means no other tests will be run!"
             [ test "This test will be run" <|
                   \_ -> 1 + 1 |> Expect.equal 2
-            , skip <| "This test will be skipped, even though it's in an only!" <|
+            , skip <| test "This test will be skipped, even though it's in an only!" <|
                   \_ -> 2 + 3 |> Expect.equal 4
             ]
         , test "This test will be skipped because it has no only" <|


### PR DESCRIPTION
The `skip` function signature is `Test.Test -> Test.Test`, but in this example the first argument is a String (the description). It appears the documentation has gotten out of date.

I looked briefly at the in-code documentation, and it looked OK (example is `skip describe`). Hopefully this is helpful!

Thank you for your hard work on a useful tool for everyone! ❤️ 