### PR TITLE
Don't distribute seeds to unit tests

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -122,7 +122,6 @@ For example: Is `1 + 2 - 3` within `1%` of `0`? Well, if `1`, `2` and `3` have a
 
 Another example is comparing values that are on either side of zero. `0.0001` is more than `100%` away from `-0.0001`. In fact, `infinity` is closer to `0.0001` than `0.0001` is to `-0.0001`, if you are using a relative tolerance. Twice as close, actually. So even though both `0.0001` and `-0.0001` could be considered very close to zero, they are very far apart relative to each other. The same argument applies for any number of zeroes.
 
-
 -}
 
 import Dict exposing (Dict)

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -138,7 +138,7 @@ test untrimmedDesc thunk =
     if String.isEmpty desc then
         Internal.blankDescriptionFailure
     else
-        Internal.Labeled desc (Internal.Test (\_ _ -> [ thunk () ]))
+        Internal.Labeled desc (Internal.UnitTest (\() -> [ thunk () ]))
 
 
 {-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests
@@ -304,8 +304,11 @@ fuzzWith options fuzzer desc getTest =
 fuzzWithHelp : FuzzOptions -> Test -> Test
 fuzzWithHelp options test =
     case test of
-        Internal.Test run ->
-            Internal.Test (\seed _ -> run seed options.runs)
+        Internal.UnitTest _ ->
+            test
+
+        Internal.FuzzTest run ->
+            Internal.FuzzTest (\seed _ -> run seed options.runs)
 
         Internal.Labeled label subTest ->
             Internal.Labeled label (fuzzWithHelp options subTest)

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -51,7 +51,7 @@ validatedFuzzTest fuzzer desc getExpectation =
                     |> Dict.toList
                     |> List.map formatExpectation
     in
-    Labeled desc (Test run)
+    Labeled desc (FuzzTest run)
 
 
 type alias Failures =

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -6,7 +6,8 @@ import Test.Expectation exposing (Expectation(..))
 
 
 type Test
-    = Test (Random.Seed -> Int -> List Expectation)
+    = UnitTest (() -> List Expectation)
+    | FuzzTest (Random.Seed -> Int -> List Expectation)
     | Labeled String Test
     | Skipped Test
     | Only Test
@@ -17,8 +18,8 @@ type Test
 -}
 failNow : { description : String, reason : Test.Expectation.Reason } -> Test
 failNow record =
-    Test
-        (\_ _ -> [ Test.Expectation.fail record ])
+    UnitTest
+        (\() -> [ Test.Expectation.fail record ])
 
 
 blankDescriptionFailure : Test
@@ -41,7 +42,10 @@ duplicatedName =
                 Batch subtests ->
                     List.concatMap names subtests
 
-                Test _ ->
+                UnitTest _ ->
+                    []
+
+                FuzzTest _ ->
                     []
 
                 Skipped subTest ->

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -211,7 +211,14 @@ Some design notes:
 distributeSeeds : Int -> Random.Seed -> Test -> Distribution
 distributeSeeds runs seed test =
     case test of
-        Internal.Test run ->
+        Internal.UnitTest run ->
+            { seed = seed
+            , all = [ Runnable (Thunk (\_ -> run ())) ]
+            , only = []
+            , skipped = []
+            }
+
+        Internal.FuzzTest run ->
             let
                 ( firstSeed, nextSeed ) =
                     Random.step Random.independentSeed seed

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -7,7 +7,7 @@ import Shrink
 import String
 import Test exposing (Test)
 import Test.Expectation exposing (Expectation(..))
-import Test.Internal as TI
+import Test.Internal as Internal
 
 
 expectPass : a -> Expectation
@@ -38,48 +38,71 @@ succeeded expectation =
             False
 
 
+passesToFails :
+    ({ reason : Test.Expectation.Reason
+     , description : String
+     , given : Maybe String
+     }
+     -> Maybe String
+    )
+    -> List Expectation
+    -> List Expectation
+passesToFails f expectations =
+    expectations
+        |> List.filterMap (passToFail f)
+        |> List.map Expect.fail
+        |> (\list ->
+                if List.isEmpty list then
+                    [ Expect.pass ]
+                else
+                    list
+           )
+
+
+passToFail :
+    ({ reason : Test.Expectation.Reason
+     , description : String
+     , given : Maybe String
+     }
+     -> Maybe String
+    )
+    -> Expectation
+    -> Maybe String
+passToFail f expectation =
+    case expectation of
+        Pass ->
+            Just "Expected this test to fail, but it passed!"
+
+        Fail record ->
+            f record
+
+
 expectFailureHelper : ({ description : String, given : Maybe String, reason : Test.Expectation.Reason } -> Maybe String) -> Test -> Test
 expectFailureHelper f test =
     case test of
-        TI.Test runTest ->
-            TI.Test
-                (\seed runs ->
-                    let
-                        expectations =
-                            runTest seed runs
+        Internal.UnitTest runTest ->
+            Internal.UnitTest <|
+                \() ->
+                    passesToFails f (runTest ())
 
-                        goodShrink expectation =
-                            case expectation of
-                                Pass ->
-                                    Just "Expected this test to fail, but it passed!"
+        Internal.FuzzTest runTest ->
+            Internal.FuzzTest <|
+                \seed runs ->
+                    passesToFails f (runTest seed runs)
 
-                                Fail record ->
-                                    f record
-                    in
-                    expectations
-                        |> List.filterMap goodShrink
-                        |> List.map Expect.fail
-                        |> (\list ->
-                                if List.isEmpty list then
-                                    [ Expect.pass ]
-                                else
-                                    list
-                           )
-                )
+        Internal.Labeled desc labeledTest ->
+            Internal.Labeled desc (expectFailureHelper f labeledTest)
 
-        TI.Labeled desc labeledTest ->
-            TI.Labeled desc (expectFailureHelper f labeledTest)
+        Internal.Batch tests ->
+            Internal.Batch (List.map (expectFailureHelper f) tests)
 
-        TI.Batch tests ->
-            TI.Batch (List.map (expectFailureHelper f) tests)
-
-        TI.Skipped subTest ->
+        Internal.Skipped subTest ->
             expectFailureHelper f subTest
-                |> TI.Skipped
+                |> Internal.Skipped
 
-        TI.Only subTest ->
+        Internal.Only subTest ->
             expectFailureHelper f subTest
-                |> TI.Only
+                |> Internal.Only
 
 
 testShrinking : Test -> Test

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -1,4 +1,4 @@
-module Helpers exposing (expectPass, expectToFail, randomSeedFuzzer, succeeded, testShrinking, testStringLengthIsPreserved, same, different)
+module Helpers exposing (different, expectPass, expectToFail, randomSeedFuzzer, same, succeeded, testShrinking, testStringLengthIsPreserved)
 
 import Expect
 import Fuzz exposing (Fuzzer)

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -110,6 +110,7 @@ randomSeedFuzzer =
     Fuzz.custom (Random.int 0 0xFFFFFFFF) Shrink.noShrink |> Fuzz.map Random.initialSeed
 
 
+same : Expectation -> Expectation -> Expectation
 same a b =
     case ( a, b ) of
         ( Test.Expectation.Pass, Test.Expectation.Pass ) ->
@@ -122,6 +123,7 @@ same a b =
             Test.Expectation.fail { description = "expected both arguments to fail, or both to succeed", reason = Test.Expectation.Equals (toString a) (toString b) }
 
 
+different : Expectation -> Expectation -> Expectation
 different a b =
     case ( a, b ) of
         ( Test.Expectation.Pass, Test.Expectation.Fail _ ) ->

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -9,7 +9,11 @@ Note that this always uses an initial seed of 902101337, since it can't do effec
 -}
 
 import Platform
+import Random.Pcg as Random
 import Runner.Log
+import Runner.String exposing (Summary)
+import SeedTests
+import Test exposing (Test)
 import Tests
 
 
@@ -21,3 +25,45 @@ main =
         , subscriptions = \_ -> Sub.none
         }
         |> Runner.Log.run Tests.all
+        -- All seed tests should pass because they receive the same initial seed.
+        |> runAllTests 1 SeedTests.fixedSeed SeedTests.tests
+
+
+runAllTests : Int -> Random.Seed -> List Test -> a -> a
+runAllTests runs seed tests =
+    tests
+        |> List.foldl
+            (\test summary ->
+                Runner.String.runWithOptions runs seed test
+                    |> combineSummaries summary
+            )
+            emptySummary
+        |> Runner.Log.logOutput
+
+
+emptySummary : Summary
+emptySummary =
+    { output = "", passed = 0, failed = 0, autoFail = Nothing }
+
+
+combineSummaries : Summary -> Summary -> Summary
+combineSummaries first second =
+    { output = first.output ++ second.output
+    , passed = first.passed + second.passed
+    , failed = first.failed + second.failed
+    , autoFail =
+        case ( first.autoFail, second.autoFail ) of
+            ( Nothing, Nothing ) ->
+                Nothing
+
+            ( Nothing, second ) ->
+                second
+
+            ( first, Nothing ) ->
+                first
+
+            ( Just first, Just second ) ->
+                [ first, second ]
+                    |> String.join "\n"
+                    |> Just
+    }

--- a/tests/Runner/Log.elm
+++ b/tests/Runner/Log.elm
@@ -26,7 +26,7 @@ import Test exposing (Test)
 
 {-| Run the test using the default `Test.Runner.String` options.
 -}
-run : Test -> a -> a
+run : Test -> ()
 run test =
     Runner.String.run test
         |> logOutput
@@ -34,7 +34,7 @@ run test =
 
 {-| Run the test using the provided options.
 -}
-runWithOptions : Int -> Random.Seed -> Test -> a -> a
+runWithOptions : Int -> Random.Seed -> Test -> ()
 runWithOptions runs seed test =
     Runner.String.runWithOptions runs seed test
         |> logOutput
@@ -62,8 +62,8 @@ summarize { output, passed, failed, autoFail } =
         ]
 
 
-logOutput : Summary -> a -> a
-logOutput summary arg =
+logOutput : Summary -> ()
+logOutput summary =
     let
         output =
             summarize summary ++ "\n\nExit code"
@@ -79,4 +79,4 @@ logOutput summary arg =
                     |> flip Debug.log 0
                     |> (\_ -> ())
     in
-    arg
+    ()

--- a/tests/Runner/Log.elm
+++ b/tests/Runner/Log.elm
@@ -1,4 +1,4 @@
-module Runner.Log exposing (run, runWithOptions)
+module Runner.Log exposing (logOutput, run, runWithOptions)
 
 {-| Log Runner
 

--- a/tests/SeedTests.elm
+++ b/tests/SeedTests.elm
@@ -1,0 +1,72 @@
+module SeedTests exposing (fixedSeed, tests)
+
+import Expect exposing (FloatingPointTolerance(Absolute, AbsoluteOrRelative, Relative))
+import Fuzz exposing (..)
+import Random.Pcg as Random
+import Test exposing (..)
+
+
+fixedSeed : Random.Seed
+fixedSeed =
+    Random.initialSeed 133742
+
+
+expectedNum : Int
+expectedNum =
+    1083264770
+
+
+{-| Most of the tests will use this, but we won't run it directly.
+
+When these tests are run using fixedSeed and a run count of 1, this is the
+exact number they will get when the description around this fuzz test is
+exactly the string "Seed test".
+
+-}
+fuzzTest : Test
+fuzzTest =
+    fuzz int "It receives the expected number" <|
+        \num ->
+            Expect.equal num expectedNum
+
+
+tests : List Test
+tests =
+    [ describe "Seed test"
+        [ fuzzTest ]
+    , describe "Seed test"
+        [ fuzz int "It receives the expected number even though this text is different" <|
+            \num ->
+                Expect.equal num expectedNum
+        ]
+    , describe "Seed test"
+        [ describe "Nested describes shouldn't affect seed distribution"
+            [ fuzzTest ]
+        ]
+    , describe "Seed test"
+        [ test "Unit tests before should not affect seed distribution" <|
+            \_ ->
+                Expect.pass
+        , fuzzTest
+        , test "Unit tests after should not affect seed distribution" <|
+            \_ ->
+                Expect.pass
+        ]
+    , -- Wrapping in a Test.concat shouldn't change anything
+      Test.concat
+        [ describe "Seed test"
+            [ fuzzTest ]
+        ]
+    , -- Wrapping in a Test.concat wth unit tests shouldn't change anything
+      Test.concat
+        [ describe "Seed test"
+            [ test "Unit tests before should not affect seed distribution" <|
+                \_ ->
+                    Expect.pass
+            , fuzzTest
+            , test "Unit tests after should not affect seed distribution" <|
+                \_ ->
+                    Expect.pass
+            ]
+        ]
+    ]

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,19 +1,22 @@
-var compiler = require("node-elm-compiler")
+var compiler = require("node-elm-compiler");
 
-testFile = "Main.elm"
+testFile = "Main.elm";
 
-compiler.compileToString([testFile], {}).then(function(str) {
-  try {
-    eval(str);
+compiler
+  .compileToString([testFile], {})
+  .then(function(str) {
+    try {
+      eval(str);
 
-    process.exit(0)
-  } catch (err) {
+      process.exit(0);
+    } catch (err) {
+      console.error(err);
+
+      process.exit(1);
+    }
+  })
+  .catch(function(err) {
     console.error(err);
 
-    process.exit(1)
-  }
-}).catch(function(err) {
-  console.error(err);
-
-  process.exit(1)
-});
+    process.exit(1);
+  });


### PR DESCRIPTION
Currently we distribute new seeds to each unit test, even though those tests never use seeds. This distinguishes internally between fuzz tests and unit tests, and skips generating fresh seeds for unit tests.

This also adds seed distribution tests.