### PR TITLE
Incorporate outermost labels into seed distribution

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,6 +13,7 @@
         "Fuzz"
     ],
     "dependencies": {
+        "Skinney/fnv": "1.0.4 <= v < 2.0.0",
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -40,6 +40,7 @@ These functions give you the ability to run fuzzers separate of running fuzz tes
 
 -}
 
+import Bitwise
 import Expect exposing (Expectation)
 import FNV
 import Fuzz exposing (Fuzzer)
@@ -266,10 +267,11 @@ distributeSeedsHelp hashed runs seed test =
                             |> Tuple.first
 
                     hashedSeed =
-                        -- Incorporate the originally passed-in seed
-                        (toString intFromSeed ++ description)
+                        description
                             -- Hash from String to Int
                             |> FNV.hashString
+                            -- Incorporate the originally passed-in seed
+                            |> Bitwise.xor intFromSeed
                             -- Convert Int back to Seed
                             |> Random.initialSeed
 

--- a/tests/SeedTests.elm
+++ b/tests/SeedTests.elm
@@ -13,12 +13,12 @@ fixedSeed =
 
 expectedNum : Int
 expectedNum =
-    1083264770
+    -2287493601
 
 
 oneSeedAlreadyDistributed : Int
 oneSeedAlreadyDistributed =
-    1463443676
+    27
 
 
 {-| Most of the tests will use this, but we won't run it directly.
@@ -87,6 +87,23 @@ tests =
             [ fuzzTest
             , fuzzTestAfterOneDistributed
             ]
+        ]
+    , Test.concat
+        [ fuzz int "top-level fuzz tests don't affect subsequent top-level fuzz tests, since they use their labels to get different seeds" <|
+            \num ->
+                Expect.equal num -68743824
+        , describe "Seed test"
+            [ fuzzTest ]
+        , describe "another top-level fuzz test"
+            [ fuzz int "it still gets different values, due to computing the seed as a hash of the label, and these labels must be unique" <|
+                \num ->
+                    Expect.equal num -797247838
+            ]
+        ]
+    , describe "Fuzz tests with different outer describe texts get different seeds"
+        [ fuzz int "It receives the expected number" <|
+            \num ->
+                Expect.equal num -3255451976
         ]
     ]
 

--- a/tests/SeedTests.elm
+++ b/tests/SeedTests.elm
@@ -13,12 +13,12 @@ fixedSeed =
 
 expectedNum : Int
 expectedNum =
-    -2287493601
+    2800615587
 
 
 oneSeedAlreadyDistributed : Int
 oneSeedAlreadyDistributed =
-    27
+    1762317316
 
 
 {-| Most of the tests will use this, but we won't run it directly.
@@ -91,19 +91,19 @@ tests =
     , Test.concat
         [ fuzz int "top-level fuzz tests don't affect subsequent top-level fuzz tests, since they use their labels to get different seeds" <|
             \num ->
-                Expect.equal num -68743824
+                Expect.equal num -32
         , describe "Seed test"
             [ fuzzTest ]
         , describe "another top-level fuzz test"
             [ fuzz int "it still gets different values, due to computing the seed as a hash of the label, and these labels must be unique" <|
                 \num ->
-                    Expect.equal num -797247838
+                    Expect.equal num 827294661
             ]
         ]
     , describe "Fuzz tests with different outer describe texts get different seeds"
         [ fuzz int "It receives the expected number" <|
             \num ->
-                Expect.equal num -3255451976
+                Expect.equal num 27
         ]
     ]
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,6 +9,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "Skinney/fnv": "1.0.4 <= v < 2.0.0",
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",


### PR DESCRIPTION
Fixes #192 by using the outermost label (which is guaranteed to be unique) in conjunction with the initial seed to determine the initial seed used for distribution of tests under that label - instead of using all the seeds that have been distributed up to that point.

Since `node-test-runner` wraps each module's tests in a label with that name (e.g. running `elm-test tests/DreamwriterTests.elm` would wrap an implicit `describe "DreamwriterTests" [ ... ]` around the tests in that module), this change means that if you pass the same `--seed` but change up which files you pass, you'll still get the same results on a per-file basis.

This also means test runners can distribute seeds in parallel within labels, assuming that actually benchmarks better.