### PR TITLE
Remove FNV dependency

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,7 +13,6 @@
         "Fuzz"
     ],
     "dependencies": {
-        "Skinney/fnv": "1.0.4 <= v < 2.0.0",
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -41,8 +41,8 @@ These functions give you the ability to run fuzzers separate of running fuzz tes
 -}
 
 import Bitwise
+import Char
 import Expect exposing (Expectation)
-import FNV
 import Fuzz exposing (Fuzzer)
 import Lazy.List as LazyList exposing (LazyList)
 import Random.Pcg as Random
@@ -269,9 +269,9 @@ distributeSeedsHelp hashed runs seed test =
                     hashedSeed =
                         description
                             -- Hash from String to Int
-                            |> FNV.hashString
+                            |> fnvHashString fnvInit
                             -- Incorporate the originally passed-in seed
-                            |> Bitwise.xor intFromSeed
+                            |> fnvHash intFromSeed
                             -- Convert Int back to Seed
                             |> Random.initialSeed
 
@@ -325,6 +325,19 @@ batchDistribute hashed runs test prev =
     , skipped = prev.skipped ++ next.skipped
     }
 
+
+{-| FNV-1a initial hash value -}
+fnvInit = 2166136261
+
+{-| FNV-1a helper for strings, using Char.toCode -}
+fnvHashString : Int -> String -> Int
+fnvHashString hash str =
+  str |> String.toList |> List.map Char.toCode |> List.foldl fnvHash hash
+
+{-| FNV-1a implementation. -}
+fnvHash : Int -> Int -> Int
+fnvHash a b =
+  (Bitwise.xor a b) * (16777619) |> Bitwise.shiftRightZfBy 0
 
 {-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
 

--- a/tests/SeedTests.elm
+++ b/tests/SeedTests.elm
@@ -6,16 +6,9 @@ import Random.Pcg as Random
 import Test exposing (..)
 
 
-fixedSeed : Random.Seed
-fixedSeed =
-    Random.initialSeed 133742
+-- NOTE: These tests are only here so that we can watch out for regressions. All constants in this file are what the implementation happened to output, not what we expected the implementation to output.
 
 
-{- This is the expected first int output when running this file with a constant seed.
-
-    (\intFromSeed -> fnvHashString fnvInit "Seed test" |> fnvHash intFromSeed)
-
--}
 expectedNum : Int
 expectedNum =
     -3954212174
@@ -24,6 +17,11 @@ expectedNum =
 oneSeedAlreadyDistributed : Int
 oneSeedAlreadyDistributed =
     198384431
+
+
+fixedSeed : Random.Seed
+fixedSeed =
+    Random.initialSeed 133742
 
 
 {-| Most of the tests will use this, but we won't run it directly.

--- a/tests/SeedTests.elm
+++ b/tests/SeedTests.elm
@@ -11,14 +11,19 @@ fixedSeed =
     Random.initialSeed 133742
 
 
+{- This is the expected first int output when running this file with a constant seed.
+
+    (\intFromSeed -> fnvHashString fnvInit "Seed test" |> fnvHash intFromSeed)
+
+-}
 expectedNum : Int
 expectedNum =
-    2800615587
+    -3954212174
 
 
 oneSeedAlreadyDistributed : Int
 oneSeedAlreadyDistributed =
-    1762317316
+    198384431
 
 
 {-| Most of the tests will use this, but we won't run it directly.
@@ -91,19 +96,19 @@ tests =
     , Test.concat
         [ fuzz int "top-level fuzz tests don't affect subsequent top-level fuzz tests, since they use their labels to get different seeds" <|
             \num ->
-                Expect.equal num -32
+                Expect.equal num 409469537
         , describe "Seed test"
             [ fuzzTest ]
         , describe "another top-level fuzz test"
             [ fuzz int "it still gets different values, due to computing the seed as a hash of the label, and these labels must be unique" <|
                 \num ->
-                    Expect.equal num 827294661
+                    Expect.equal num 0
             ]
         ]
     , describe "Fuzz tests with different outer describe texts get different seeds"
         [ fuzz int "It receives the expected number" <|
             \num ->
-                Expect.equal num 27
+                Expect.equal num 2049737128
         ]
     ]
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,7 +9,6 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "Skinney/fnv": "1.0.4 <= v < 2.0.0",
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",


### PR DESCRIPTION
This is a simple replacement of the FNV dependency with our own implementation. It also has slightly better entropy when incorporating the `initFromSeed` into the hash. 