### PR TITLE
Improve list shrinking

### DIFF
--- a/benchmarks/Snippets.elm
+++ b/benchmarks/Snippets.elm
@@ -100,7 +100,15 @@ listIntFail : Test
 listIntFail =
     fuzz (Fuzz.list Fuzz.int) "(fails) list of int" <|
         \numbers ->
-            Expect.fail "Failed"
+            case numbers of
+                [] ->
+                    {- The empty list is the first value the list shrinker will try.
+                       If we immediately fail on that example than we're not doing a lot of shrinking.
+                    -}
+                    Expect.pass
+
+                _ ->
+                    Expect.fail "Failed"
 
 
 maybeIntPass : Test

--- a/benchmarks/Snippets.elm
+++ b/benchmarks/Snippets.elm
@@ -99,16 +99,10 @@ listIntPass =
 listIntFail : Test
 listIntFail =
     fuzz (Fuzz.list Fuzz.int) "(fails) list of int" <|
-        \numbers ->
-            case numbers of
-                [] ->
-                    {- The empty list is the first value the list shrinker will try.
-                       If we immediately fail on that example than we're not doing a lot of shrinking.
-                    -}
-                    Expect.pass
-
-                _ ->
-                    Expect.fail "Failed"
+        {- The empty list is the first value the list shrinker will try.
+           If we immediately fail on that example than we're not doing a lot of shrinking.
+        -}
+        Expect.notEqual []
 
 
 maybeIntPass : Test

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -383,6 +383,8 @@ listShrinkRecurse listOfTrees =
                         Lazy.List.fromList [ dropFirstHalf listOfTrees, dropSecondHalf listOfTrees ]
                             |> Lazy.force
             else
+                -- For lists of three elements or less, halving and removing a single element is often going to be the same thing.
+                -- To prevent us from attempting the same shrunken value twice, we're disabling the halving strategy for these small lists.
                 Lazy.List.empty
 
         shrinkOne prefix list =

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -344,11 +344,13 @@ list fuzzer =
 listShrinkHelp : List (RoseTree a) -> RoseTree (List a)
 listShrinkHelp listOfTrees =
     {- This extends listShrinkRecurse algorithm with an attempt to shrink directly to the empty list. -}
-    let
-        (Rose root children) =
-            listShrinkRecurse listOfTrees
-    in
-    Rose root (Lazy.List.cons (RoseTree.singleton []) children)
+    listShrinkRecurse listOfTrees
+        |> mapChildren (Lazy.List.cons <| RoseTree.singleton [])
+
+
+mapChildren : (LazyList (RoseTree a) -> LazyList (RoseTree a)) -> RoseTree a -> RoseTree a
+mapChildren fn (Rose root children) =
+    Rose root (fn children)
 
 
 listShrinkRecurse : List (RoseTree a) -> RoseTree (List a)

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -344,9 +344,11 @@ list fuzzer =
 listShrinkHelp : List (RoseTree a) -> RoseTree (List a)
 listShrinkHelp listOfTrees =
     {- This extends listShrinkRecurse algorithm with an attempt to shrink directly to the empty list. -}
-    case listShrinkRecurse listOfTrees of
-        Rose root children ->
-            Rose root (Lazy.List.cons (RoseTree.singleton []) children)
+    let
+        (Rose root children) =
+            listShrinkRecurse listOfTrees
+    in
+    Rose root (Lazy.List.cons (RoseTree.singleton []) children)
 
 
 listShrinkRecurse : List (RoseTree a) -> RoseTree (List a)

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -365,6 +365,26 @@ listShrinkRecurse listOfTrees =
         root =
             List.map RoseTree.root listOfTrees
 
+        dropFirstHalf : List (RoseTree a) -> RoseTree (List a)
+        dropFirstHalf list_ =
+            List.drop (List.length list_ // 2) list_
+                |> listShrinkRecurse
+
+        dropSecondHalf : List (RoseTree a) -> RoseTree (List a)
+        dropSecondHalf list_ =
+            List.take (List.length list_ // 2) list_
+                |> listShrinkRecurse
+
+        halved : LazyList (RoseTree (List a))
+        halved =
+            if n >= 4 then
+                Lazy.lazy <|
+                    \_ ->
+                        Lazy.List.fromList [ dropFirstHalf listOfTrees, dropSecondHalf listOfTrees ]
+                            |> Lazy.force
+            else
+                Lazy.List.empty
+
         shrinkOne prefix list =
             case list of
                 [] ->
@@ -397,8 +417,7 @@ listShrinkRecurse listOfTrees =
                 (List.take index list)
                 (List.drop (index + 1) list)
     in
-    Lazy.List.append shortened shrunkenVals
-        |> Rose root
+    Rose root (halved +++ shortened +++ shrunkenVals)
 
 
 {-| Given a fuzzer of a type, create a fuzzer of an array of that type.

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -377,14 +377,14 @@ listShrinkRecurse listOfTrees =
 
         halved : LazyList (RoseTree (List a))
         halved =
-            if n >= 4 then
+            -- The list halving shortcut is useful only for large lists.
+            -- For small lists attempting to remove elements one by one is good enough.
+            if n >= 8 then
                 Lazy.lazy <|
                     \_ ->
                         Lazy.List.fromList [ dropFirstHalf listOfTrees, dropSecondHalf listOfTrees ]
                             |> Lazy.force
             else
-                -- For lists of three elements or less, halving and removing a single element is often going to be the same thing.
-                -- To prevent us from attempting the same shrunken value twice, we're disabling the halving strategy for these small lists.
                 Lazy.List.empty
 
         shrinkOne prefix list =


### PR DESCRIPTION
This PR aims to improve the performance of shrinking large lists. I've noticed fuzz tests occasionally hang when shrinking lists containing large fuzzed items. Especially when you're fuzzing nested list structures shrinking can take a while because it shrinks one item at a time.

This PR contains two changes:
- It no longer tries the empty list every other shrinking step, which I believe resolves #187.
- It will optimistically try to delete the first and last half of the list before attempting more costly list shrinking strategies.

In the benchmarks (which I made marginally more realistic) these changes result in an over 100x performance improvement for shrinking a list of ints.

It is debatable whether I'm picking 'the right halves' to try and throw away. Other possible strategies include  removing all even or odd elements or removing at random. My feeling, unsupported by evidence, is that when a test fails on a large list, 9 out of 10 times the problem will be relatively simple. That means there's decent odds the problem lies entirely within either half of the list. Further optimisations might be possible for the case where you're discovering a complex problem arising from many elements in the list working in concert, but waiting a bit longer for the shrinker in those scenario's seems ok to me for now.

The same optimisation can be made for string shrinking, but this PR does not contain it because the string shrinker lives in elm-shrink.