### PR TITLE
Make Fuzz.string generate more whitespace-only strings

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -253,16 +253,19 @@ percentage =
 
 
 {-| A fuzzer for char values. Generates random ascii chars disregarding the control
-characters.
+characters and the extended character set. Generates whitespace characters about 10% of the time.
 -}
 char : Fuzzer Char
 char =
-    custom charGenerator Shrink.character
+    custom asciiCharGenerator Shrink.character
 
 
-charGenerator : Generator Char
-charGenerator =
-    Random.map Char.fromCode (Random.int 32 126)
+asciiCharGenerator : Generator Char
+asciiCharGenerator =
+    Random.frequency
+        [ ( 1, Random.sample [ ' ', '\t', '\n' ] |> Random.map (Maybe.withDefault ' ') )
+        , ( 9, Random.map Char.fromCode (Random.int 33 126) )
+        ]
 
 
 {-| Generates random printable ASCII strings of up to 1000 characters.
@@ -281,7 +284,7 @@ string =
                 , ( 1, Random.int 11 50 )
                 , ( 1, Random.int 50 1000 )
                 ]
-                |> Random.andThen (lengthString charGenerator)
+                |> Random.andThen (lengthString asciiCharGenerator)
     in
     custom generator Shrink.string
 

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -253,7 +253,7 @@ percentage =
 
 
 {-| A fuzzer for char values. Generates random ascii chars disregarding the control
-characters and the extended character set. Generates whitespace characters about 10% of the time.
+characters and the extended character set.
 -}
 char : Fuzzer Char
 char =
@@ -262,10 +262,12 @@ char =
 
 asciiCharGenerator : Generator Char
 asciiCharGenerator =
-    Random.frequency
-        [ ( 1, Random.sample [ ' ', '\t', '\n' ] |> Random.map (Maybe.withDefault ' ') )
-        , ( 9, Random.map Char.fromCode (Random.int 33 126) )
-        ]
+    Random.map Char.fromCode (Random.int 32 126)
+
+
+whitespaceCharGenerator : Generator Char
+whitespaceCharGenerator =
+    Random.sample [ ' ', '\t', '\n' ] |> Random.map (Maybe.withDefault ' ')
 
 
 {-| Generates random printable ASCII strings of up to 1000 characters.
@@ -285,8 +287,19 @@ string =
                 , ( 1, Random.int 50 1000 )
                 ]
                 |> Random.andThen (lengthString asciiCharGenerator)
+
+        whitespaceGenerator : Generator String
+        whitespaceGenerator =
+            Random.int 1 10
+                |> Random.andThen (lengthString whitespaceCharGenerator)
     in
-    custom generator Shrink.string
+    custom
+        (Random.frequency
+            [ ( 9, generator )
+            , ( 1, whitespaceGenerator )
+            ]
+        )
+        Shrink.string
 
 
 {-| Given a fuzzer of a type, create a fuzzer of a maybe for that type.

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -278,8 +278,8 @@ Shorter strings are more common, especially the empty string.
 string : Fuzzer String
 string =
     let
-        generator : Generator String
-        generator =
+        asciiGenerator : Generator String
+        asciiGenerator =
             Random.frequency
                 [ ( 3, Random.int 1 10 )
                 , ( 0.2, Random.constant 0 )
@@ -295,7 +295,7 @@ string =
     in
     custom
         (Random.frequency
-            [ ( 9, generator )
+            [ ( 9, asciiGenerator )
             , ( 1, whitespaceGenerator )
             ]
         )

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -326,18 +326,25 @@ batchDistribute hashed runs test prev =
     }
 
 
-{-| FNV-1a initial hash value -}
-fnvInit = 2166136261
+{-| FNV-1a initial hash value
+-}
+fnvInit =
+    2166136261
 
-{-| FNV-1a helper for strings, using Char.toCode -}
+
+{-| FNV-1a helper for strings, using Char.toCode
+-}
 fnvHashString : Int -> String -> Int
 fnvHashString hash str =
-  str |> String.toList |> List.map Char.toCode |> List.foldl fnvHash hash
+    str |> String.toList |> List.map Char.toCode |> List.foldl fnvHash hash
 
-{-| FNV-1a implementation. -}
+
+{-| FNV-1a implementation.
+-}
 fnvHash : Int -> Int -> Int
 fnvHash a b =
-  (Bitwise.xor a b) * (16777619) |> Bitwise.shiftRightZfBy 0
+    Bitwise.xor a b * 16777619 |> Bitwise.shiftRightZfBy 0
+
 
 {-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
 


### PR DESCRIPTION
This is a quick-fix for #198. It uniformly picks between space, tab and non-windows-style newline characters 10% of the time, otherwise it behaves like before.

It also elm-formats [the FNV implementation](https://github.com/elm-community/elm-test/pull/197). I could put that in another PR if you want me to.

The full unicode solution is blocked while we wait for a new release of [elm-lang/core](https://github.com/elm-lang/core/commit/8e885c9bd4a7556ee039e2f53bbb3a1555d0243e).