### PR TITLE
Expose failure Reason directly

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -9,7 +9,7 @@
     "exposed-modules": [
         "Test",
         "Test.Runner",
-        "Test.Runner.Reason",
+        "Test.Runner.Failure",
         "Expect",
         "Fuzz"
     ],

--- a/elm-package.json
+++ b/elm-package.json
@@ -9,6 +9,7 @@
     "exposed-modules": [
         "Test",
         "Test.Runner",
+        "Test.Runner.Reason",
         "Expect",
         "Fuzz"
     ],

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -499,6 +499,10 @@ equalLists expected actual =
     if expected == actual then
         pass
     else
+        { description = "Expect.equalLists"
+        , reason = ListDiff (List.map toString expected) (List.map toString actual)
+        }
+            |> Test.Expectation.fail
 
 
 {-| Passes if the arguments are equal dicts.

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -782,7 +782,7 @@ reportCollectionFailure comparison expected actual missingKeys extraKeys =
 -}
 equateWith : String -> (a -> b -> Bool) -> b -> a -> Expectation
 equateWith =
-    testWith Equals
+    testWith Equality
 
 
 compareWith : String -> (a -> b -> Bool) -> b -> a -> Expectation

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -499,35 +499,6 @@ equalLists expected actual =
     if expected == actual then
         pass
     else
-        equalListsHelp 0 expected actual
-
-
-equalListsHelp : Int -> List a -> List a -> Expectation
-equalListsHelp index expected actual =
-    case ( expected, actual ) of
-        ( [], [] ) ->
-            pass
-
-        ( first :: _, [] ) ->
-            reportFailure "Expect.equalLists was shorter than" (toString expected) (toString actual)
-
-        ( [], first :: _ ) ->
-            reportFailure "Expect.equalLists was longer than" (toString expected) (toString actual)
-
-        ( firstExpected :: restExpected, firstActual :: restActual ) ->
-            if firstExpected == firstActual then
-                -- They're still the same so far; keep going.
-                equalListsHelp (index + 1) restExpected restActual
-            else
-                -- We found elements that differ; fail!
-                Test.Expectation.fail
-                    { description = "Expect.equalLists"
-                    , reason =
-                        ListDiff
-                            (toString expected)
-                            (toString actual)
-                            ( index, toString firstExpected, toString firstActual )
-                    }
 
 
 {-| Passes if the arguments are equal dicts.

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -127,7 +127,7 @@ Another example is comparing values that are on either side of zero. `0.0001` is
 import Dict exposing (Dict)
 import Set exposing (Set)
 import Test.Expectation
-import Test.Runner.Reason exposing (InvalidReason(..), Reason(..))
+import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
 
 {-| The result of a single test run: either a [`pass`](#pass) or a

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -127,6 +127,7 @@ Another example is comparing values that are on either side of zero. `0.0001` is
 import Dict exposing (Dict)
 import Set exposing (Set)
 import Test.Expectation
+import Test.Runner.Reason exposing (InvalidReason(..), Reason(..))
 
 
 {-| The result of a single test run: either a [`pass`](#pass) or a
@@ -458,7 +459,7 @@ err result =
     case result of
         Ok _ ->
             { description = "Expect.err"
-            , reason = Test.Expectation.Comparison "Err _" (toString result)
+            , reason = Comparison "Err _" (toString result)
             }
                 |> Test.Expectation.fail
 
@@ -514,7 +515,7 @@ equalLists expected actual =
                         (\( index, e, a ) ->
                             let
                                 reason =
-                                    Test.Expectation.ListDiff
+                                    ListDiff
                                         (toString expected)
                                         (toString actual)
                                         ( index, toString e, toString a )
@@ -674,7 +675,7 @@ pass =
 -}
 fail : String -> Expectation
 fail str =
-    Test.Expectation.fail { description = str, reason = Test.Expectation.Custom }
+    Test.Expectation.fail { description = str, reason = Custom }
 
 
 {-| If the given expectation fails, replace its failure message with a custom one.
@@ -691,7 +692,7 @@ onFail str expectation =
             expectation
 
         Test.Expectation.Fail failure ->
-            Test.Expectation.Fail { failure | description = str, reason = Test.Expectation.Custom }
+            Test.Expectation.Fail { failure | description = str, reason = Custom }
 
 
 {-| Passes if each of the given functions passes when applied to the subject.
@@ -729,7 +730,7 @@ all : List (subject -> Expectation) -> subject -> Expectation
 all list query =
     if List.isEmpty list then
         Test.Expectation.fail
-            { reason = Test.Expectation.Invalid Test.Expectation.EmptyList
+            { reason = Invalid EmptyList
             , description = "Expect.all was given an empty list. You must make at least one expectation to have a valid test!"
             }
     else
@@ -758,7 +759,7 @@ allHelp list query =
 reportFailure : String -> String -> String -> Expectation
 reportFailure comparison expected actual =
     { description = comparison
-    , reason = Test.Expectation.Comparison (toString expected) (toString actual)
+    , reason = Comparison (toString expected) (toString actual)
     }
         |> Test.Expectation.fail
 
@@ -772,7 +773,7 @@ reportCollectionFailure comparison expected actual missingKeys extraKeys =
         , extra = List.map toString extraKeys
         , missing = List.map toString missingKeys
         }
-            |> Test.Expectation.CollectionDiff
+            |> CollectionDiff
     }
         |> Test.Expectation.fail
 
@@ -781,15 +782,15 @@ reportCollectionFailure comparison expected actual missingKeys extraKeys =
 -}
 equateWith : String -> (a -> b -> Bool) -> b -> a -> Expectation
 equateWith =
-    testWith Test.Expectation.Equals
+    testWith Equals
 
 
 compareWith : String -> (a -> b -> Bool) -> b -> a -> Expectation
 compareWith =
-    testWith Test.Expectation.Comparison
+    testWith Comparison
 
 
-testWith : (String -> String -> Test.Expectation.Reason) -> String -> (a -> b -> Bool) -> b -> a -> Expectation
+testWith : (String -> String -> Reason) -> String -> (a -> b -> Bool) -> b -> a -> Expectation
 testWith makeReason label runTest expected actual =
     if runTest actual expected then
         pass
@@ -833,11 +834,11 @@ relative tolerance =
 nonNegativeToleranceError : FloatingPointTolerance -> String -> Expectation -> Expectation
 nonNegativeToleranceError tolerance name result =
     if absolute tolerance < 0 && relative tolerance < 0 then
-        Test.Expectation.fail { description = "Expect." ++ name ++ " was given negative absolute and relative tolerances", reason = Test.Expectation.Custom }
+        Test.Expectation.fail { description = "Expect." ++ name ++ " was given negative absolute and relative tolerances", reason = Custom }
     else if absolute tolerance < 0 then
-        Test.Expectation.fail { description = "Expect." ++ name ++ " was given a negative absolute tolerance", reason = Test.Expectation.Custom }
+        Test.Expectation.fail { description = "Expect." ++ name ++ " was given a negative absolute tolerance", reason = Custom }
     else if relative tolerance < 0 then
-        Test.Expectation.fail { description = "Expect." ++ name ++ " was given a negative relative tolerance", reason = Test.Expectation.Custom }
+        Test.Expectation.fail { description = "Expect." ++ name ++ " was given a negative relative tolerance", reason = Custom }
     else
         result
 

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -19,9 +19,9 @@ module Test exposing (FuzzOptions, Test, concat, describe, fuzz, fuzz2, fuzz3, f
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer)
 import Set
-import Test.Expectation
 import Test.Fuzz
 import Test.Internal as Internal
+import Test.Runner.Reason exposing (InvalidReason(..), Reason(..))
 
 
 {-| A test which has yet to be evaluated. When evaluated, it produces one
@@ -44,14 +44,14 @@ concat tests =
     if List.isEmpty tests then
         Internal.failNow
             { description = "This `concat` has no tests in it. Let's give it some!"
-            , reason = Test.Expectation.Invalid Test.Expectation.EmptyList
+            , reason = Invalid EmptyList
             }
     else
         case Internal.duplicatedName tests of
             Err duped ->
                 Internal.failNow
                     { description = "A test group contains multiple tests named '" ++ duped ++ "'. Do some renaming so that tests have unique names."
-                    , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
+                    , reason = Invalid DuplicatedName
                     }
 
             Ok _ ->
@@ -91,26 +91,26 @@ describe untrimmedDesc tests =
     if String.isEmpty desc then
         Internal.failNow
             { description = "This `describe` has a blank description. Let's give it a useful one!"
-            , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
+            , reason = Invalid BadDescription
             }
     else if List.isEmpty tests then
         Internal.failNow
             { description = "This `describe " ++ toString desc ++ "` has no tests in it. Let's give it some!"
-            , reason = Test.Expectation.Invalid Test.Expectation.EmptyList
+            , reason = Invalid EmptyList
             }
     else
         case Internal.duplicatedName tests of
             Err duped ->
                 Internal.failNow
                     { description = "The tests '" ++ desc ++ "' contain multiple tests named '" ++ duped ++ "'. Let's rename them so we know which is which."
-                    , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
+                    , reason = Invalid DuplicatedName
                     }
 
             Ok childrenNames ->
                 if Set.member desc childrenNames then
                     Internal.failNow
                         { description = "The test '" ++ desc ++ "' contains a child test of the same name. Let's rename them so we know which is which."
-                        , reason = Test.Expectation.Invalid Test.Expectation.DuplicatedName
+                        , reason = Invalid DuplicatedName
                         }
                 else
                     Internal.Labeled desc (Internal.Batch tests)
@@ -165,7 +165,7 @@ todo : String -> Test
 todo desc =
     Internal.failNow
         { description = desc
-        , reason = Test.Expectation.TODO
+        , reason = TODO
         }
 
 
@@ -295,7 +295,7 @@ fuzzWith options fuzzer desc getTest =
     if options.runs < 1 then
         Internal.failNow
             { description = "Fuzz tests must have a run count of at least 1, not " ++ toString options.runs ++ "."
-            , reason = Test.Expectation.Invalid Test.Expectation.NonpositiveFuzzCount
+            , reason = Invalid NonpositiveFuzzCount
             }
     else
         fuzzWithHelp options (fuzz fuzzer desc getTest)

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -21,7 +21,7 @@ import Fuzz exposing (Fuzzer)
 import Set
 import Test.Fuzz
 import Test.Internal as Internal
-import Test.Runner.Reason exposing (InvalidReason(..), Reason(..))
+import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
 
 {-| A test which has yet to be evaluated. When evaluated, it produces one

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -1,36 +1,11 @@
-module Test.Expectation exposing (Expectation(..), InvalidReason(..), Reason(..), fail, withGiven)
+module Test.Expectation exposing (Expectation(..), fail, withGiven)
+
+import Test.Runner.Reason exposing (Reason)
 
 
 type Expectation
     = Pass
     | Fail { given : Maybe String, description : String, reason : Reason }
-
-
-type Reason
-    = Custom
-    | Equals String String
-    | Comparison String String
-      -- Expected, actual, (index of problem, expected element, actual element)
-    | ListDiff String String ( Int, String, String )
-      {- I don't think we need to show the diff twice with + and - reversed. Just show it after the main vertical bar.
-         "Extra" and "missing" are relative to the actual value.
-      -}
-    | CollectionDiff
-        { expected : String
-        , actual : String
-        , extra : List String
-        , missing : List String
-        }
-    | TODO
-    | Invalid InvalidReason
-
-
-type InvalidReason
-    = EmptyList
-    | NonpositiveFuzzCount
-    | InvalidFuzzer
-    | BadDescription
-    | DuplicatedName
 
 
 {-| Create a failure without specifying the given.

--- a/src/Test/Expectation.elm
+++ b/src/Test/Expectation.elm
@@ -1,6 +1,6 @@
 module Test.Expectation exposing (Expectation(..), fail, withGiven)
 
-import Test.Runner.Reason exposing (Reason)
+import Test.Runner.Failure exposing (Reason)
 
 
 type Expectation

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -8,7 +8,7 @@ import Random.Pcg as Random exposing (Generator)
 import RoseTree exposing (RoseTree(..))
 import Test.Expectation exposing (Expectation(..))
 import Test.Internal exposing (Test(..), blankDescriptionFailure, failNow)
-import Test.Runner.Reason exposing (InvalidReason(..), Reason(..))
+import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
 
 {-| Reject always-failing tests because of bad names or invalid fuzzers.

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -8,6 +8,7 @@ import Random.Pcg as Random exposing (Generator)
 import RoseTree exposing (RoseTree(..))
 import Test.Expectation exposing (Expectation(..))
 import Test.Internal exposing (Test(..), blankDescriptionFailure, failNow)
+import Test.Runner.Reason exposing (InvalidReason(..), Reason(..))
 
 
 {-| Reject always-failing tests because of bad names or invalid fuzzers.
@@ -25,7 +26,7 @@ fuzzTest fuzzer untrimmedDesc getExpectation =
             Err reason ->
                 failNow
                     { description = reason
-                    , reason = Test.Expectation.Invalid Test.Expectation.InvalidFuzzer
+                    , reason = Invalid InvalidFuzzer
                     }
 
             Ok validFuzzer ->

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -3,7 +3,7 @@ module Test.Internal exposing (Test(..), blankDescriptionFailure, duplicatedName
 import Random.Pcg as Random exposing (Generator)
 import Set exposing (Set)
 import Test.Expectation exposing (Expectation(..))
-import Test.Runner.Reason exposing (InvalidReason(..), Reason(..))
+import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
 
 type Test

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -3,6 +3,7 @@ module Test.Internal exposing (Test(..), blankDescriptionFailure, duplicatedName
 import Random.Pcg as Random exposing (Generator)
 import Set exposing (Set)
 import Test.Expectation exposing (Expectation(..))
+import Test.Runner.Reason exposing (InvalidReason(..), Reason(..))
 
 
 type Test
@@ -16,7 +17,7 @@ type Test
 
 {-| Create a test that always fails for the given reason and description.
 -}
-failNow : { description : String, reason : Test.Expectation.Reason } -> Test
+failNow : { description : String, reason : Reason } -> Test
 failNow record =
     UnitTest
         (\() -> [ Test.Expectation.fail record ])
@@ -26,7 +27,7 @@ blankDescriptionFailure : Test
 blankDescriptionFailure =
     failNow
         { description = "This test has a blank description. Let's give it a useful one!"
-        , reason = Test.Expectation.Invalid Test.Expectation.BadDescription
+        , reason = Invalid BadDescription
         }
 
 

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -7,6 +7,7 @@ module Test.Runner
         , fromTest
         , fuzz
         , getFailure
+        , getFailureReason
         , isTodo
         , shrink
         )
@@ -24,7 +25,7 @@ can be found in the `README`.
 
 ## Expectations
 
-@docs getFailure, isTodo
+@docs getFailure, getFailureReason, isTodo
 
 
 ## Formatting
@@ -347,7 +348,10 @@ fnvHash a b =
     Bitwise.xor a b * 16777619 |> Bitwise.shiftRightZfBy 0
 
 
-{-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
+{-| **DEPRECATED.** Please use [`getFailureReason`](#getFailureReason) instead.
+This function will be removed in the next major version.
+
+Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
 
 If it is a [`fail`](#fail), return a record containing the failure message,
 along with the given inputs if it was a fuzz test. (If no inputs were involved,

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -168,7 +168,15 @@ type alias Distribution =
     }
 
 
-{-| -}
+{-| Test Runners which have had seeds distributed to them, and which are now
+either invalid or are ready to run. Seeded runners include some metadata:
+
+  - `Invalid` runners had a problem (e.g. two sibling tests had the same description) making them un-runnable.
+  - `Only` runners can be run, but `Test.only` was used somewhere, so ultimately they will lead to a failed test run even if each test that gets run passes.
+  - `Skipping` runners can be run, but `Test.skip` was used somewhere, so ultimately they will lead to a failed test run even if each test that gets run passes.
+  - `Plain` runners are ready to run, and have none of these issues.
+
+-}
 type SeededRunners
     = Plain (List Runner)
     | Only (List Runner)

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -390,21 +390,28 @@ getFailure expectation =
 
 {-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
 
-If it is a [`fail`](#fail), return a record containing the failure message,
-along with the given inputs if it was a fuzz test. (If no inputs were involved,
-the record's `given` field will be `Nothing`).
+If it is a [`fail`](#fail), return a record containing the expectation
+description, the [`Reason`](#Reason) the test failed, and the given inputs if
+it was a fuzz test. (If it was not a fuzz test, the record's `given` field
+will be `Nothing`).
 
-For example, if a fuzz test generates random integers, this might return
-`{ message = "it was supposed to be positive", given = "-1" }`
+For example:
 
-    getFailure (Expect.fail "this failed")
-    -- Just { message = "this failed", given = "" }
+    getFailureReason (Expect.equal 1 2)
+    -- Just { reason = Equal 1 2, description = "Expect.equal", given = Nothing }
 
-    getFailure (Expect.pass)
+    getFailureReason (Expect.equal 1 1)
     -- Nothing
 
 -}
-getFailureReason : Expectation -> Maybe { given : Maybe String, description : String, reason : Reason }
+getFailureReason :
+    Expectation
+    ->
+        Maybe
+            { given : Maybe String
+            , description : String
+            , reason : Reason
+            }
 getFailureReason expectation =
     case expectation of
         Test.Expectation.Pass ->

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -51,7 +51,7 @@ import String
 import Test exposing (Test)
 import Test.Expectation
 import Test.Internal as Internal
-import Test.Runner.Reason exposing (Reason(..))
+import Test.Runner.Failure exposing (Reason(..))
 
 
 {-| An unevaluated test. Run it with [`run`](#run) to evaluate it into a
@@ -363,8 +363,37 @@ For example, if a fuzz test generates random integers, this might return
     -- Nothing
 
 -}
-getFailure : Expectation -> Maybe { given : Maybe String, description : String, reason : Reason }
+getFailure : Expectation -> Maybe { given : Maybe String, message : String }
 getFailure expectation =
+    case expectation of
+        Test.Expectation.Pass ->
+            Nothing
+
+        Test.Expectation.Fail record ->
+            Just
+                { given = record.given
+                , message = Test.Runner.Failure.format record
+                }
+
+
+{-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
+
+If it is a [`fail`](#fail), return a record containing the failure message,
+along with the given inputs if it was a fuzz test. (If no inputs were involved,
+the record's `given` field will be `Nothing`).
+
+For example, if a fuzz test generates random integers, this might return
+`{ message = "it was supposed to be positive", given = "-1" }`
+
+    getFailure (Expect.fail "this failed")
+    -- Just { message = "this failed", given = "" }
+
+    getFailure (Expect.pass)
+    -- Nothing
+
+-}
+getFailureReason : Expectation -> Maybe { given : Maybe String, description : String, reason : Reason }
+getFailureReason expectation =
     case expectation of
         Test.Expectation.Pass ->
             Nothing

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -1,8 +1,10 @@
 module Test.Runner
     exposing
-        ( Runner
+        ( Reason
+        , Runner
         , SeededRunners(..)
         , Shrinkable
+        , failureMessage
         , formatLabels
         , fromTest
         , fuzz
@@ -29,7 +31,7 @@ can be found in the `README`.
 
 ## Formatting
 
-@docs formatLabels
+@docs Reason, failureMessage, formatLabels
 
 
 ## Fuzzers
@@ -51,7 +53,7 @@ import String
 import Test exposing (Test)
 import Test.Expectation
 import Test.Internal as Internal
-import Test.Message exposing (failureMessage)
+import Test.Message
 
 
 {-| An unevaluated test. Run it with [`run`](#run) to evaluate it into a
@@ -59,6 +61,20 @@ list of `Expectation`s.
 -}
 type Runnable
     = Thunk (() -> List Expectation)
+
+
+type alias Reason =
+    Test.Expectation.Reason
+
+
+failureMessage :
+    { description : String
+    , given : Maybe String
+    , reason : Test.Expectation.Reason
+    }
+    -> String
+failureMessage =
+    Test.Message.failureMessage
 
 
 {-| A function which, when evaluated, produces a list of expectations. Also a
@@ -363,17 +379,14 @@ For example, if a fuzz test generates random integers, this might return
     -- Nothing
 
 -}
-getFailure : Expectation -> Maybe { given : Maybe String, message : String }
+getFailure : Expectation -> Maybe { given : Maybe String, description : String, reason : Reason }
 getFailure expectation =
     case expectation of
         Test.Expectation.Pass ->
             Nothing
 
         Test.Expectation.Fail record ->
-            Just
-                { given = record.given
-                , message = failureMessage record
-                }
+            Just record
 
 
 {-| Determine if an expectation was created by a call to `Test.todo`. Runners

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -381,10 +381,10 @@ getFailure expectation =
         Test.Expectation.Pass ->
             Nothing
 
-        Test.Expectation.Fail record ->
+        Test.Expectation.Fail { given, description, reason } ->
             Just
-                { given = record.given
-                , message = Test.Runner.Failure.format record
+                { given = given
+                , message = Test.Runner.Failure.format description reason
                 }
 
 

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -1,10 +1,8 @@
 module Test.Runner
     exposing
-        ( Reason
-        , Runner
+        ( Runner
         , SeededRunners(..)
         , Shrinkable
-        , failureMessage
         , formatLabels
         , fromTest
         , fuzz
@@ -31,7 +29,7 @@ can be found in the `README`.
 
 ## Formatting
 
-@docs Reason, failureMessage, formatLabels
+@docs formatLabels
 
 
 ## Fuzzers
@@ -53,7 +51,7 @@ import String
 import Test exposing (Test)
 import Test.Expectation
 import Test.Internal as Internal
-import Test.Message
+import Test.Runner.Reason exposing (Reason(..))
 
 
 {-| An unevaluated test. Run it with [`run`](#run) to evaluate it into a
@@ -61,20 +59,6 @@ list of `Expectation`s.
 -}
 type Runnable
     = Thunk (() -> List Expectation)
-
-
-type alias Reason =
-    Test.Expectation.Reason
-
-
-failureMessage :
-    { description : String
-    , given : Maybe String
-    , reason : Test.Expectation.Reason
-    }
-    -> String
-failureMessage =
-    Test.Message.failureMessage
 
 
 {-| A function which, when evaluated, produces a list of expectations. Also a
@@ -399,7 +383,7 @@ isTodo expectation =
             False
 
         Test.Expectation.Fail { reason } ->
-            reason == Test.Expectation.TODO
+            reason == TODO
 
 
 {-| A standard way to format descriptions and test labels, to keep things

--- a/src/Test/Runner/Failure.elm
+++ b/src/Test/Runner/Failure.elm
@@ -62,13 +62,8 @@ that make sense for their own environments.
 Format test run failures in a reasonable way.
 
 -}
-format :
-    { description : String
-    , given : Maybe String
-    , reason : Reason
-    }
-    -> String
-format { description, given, reason } =
+format : String -> Reason -> String
+format description reason =
     case reason of
         Custom ->
             description

--- a/src/Test/Runner/Failure.elm
+++ b/src/Test/Runner/Failure.elm
@@ -7,7 +7,12 @@ module Test.Runner.Failure exposing (InvalidReason(..), Reason(..), format)
 -}
 
 
-{-| -}
+{-| The reason a test failed.
+
+Test runners can use this to provide nice output, e.g. by doing diffs on the
+two parts of an `Expect.equal` failure.
+
+-}
 type Reason
     = Custom
     | Equality String String
@@ -27,7 +32,11 @@ type Reason
     | Invalid InvalidReason
 
 
-{-| -}
+{-| The reason a test run was invalid.
+
+Test runners should report these to the user in whatever format is appropriate.
+
+-}
 type InvalidReason
     = EmptyList
     | NonpositiveFuzzCount

--- a/src/Test/Runner/Failure.elm
+++ b/src/Test/Runner/Failure.elm
@@ -129,11 +129,15 @@ listDiffToString :
 listDiffToString index description { expected, actual } originals =
     case ( expected, actual ) of
         ( [], [] ) ->
-            -- This should never happen! Recurse into oblivion.
-            listDiffToString (index + 1)
-                description
-                { expected = [], actual = [] }
-                originals
+            [ "Two lists were unequal previously, yet ended up equal later."
+            , "This should never happen!"
+            , "Please report this bug to https://github.com/elm-community/elm-test/issues - and include these lists: "
+            , "\n"
+            , toString originals.originalExpected
+            , "\n"
+            , toString originals.originalActual
+            ]
+                |> String.join ""
 
         ( first :: _, [] ) ->
             verticalBar (description ++ " was shorter than")

--- a/src/Test/Runner/Failure.elm
+++ b/src/Test/Runner/Failure.elm
@@ -56,7 +56,12 @@ verticalBar comparison expected actual =
         |> String.join "\n"
 
 
-{-| -}
+{-| DEPRECATED. In the future, test runners should implement versions of this
+that make sense for their own environments.
+
+Format test run failures in a reasonable way.
+
+-}
 format :
     { description : String
     , given : Maybe String

--- a/src/Test/Runner/Failure.elm
+++ b/src/Test/Runner/Failure.elm
@@ -1,8 +1,8 @@
-module Test.Runner.Reason exposing (InvalidReason(..), Reason(..), formatFailure)
+module Test.Runner.Failure exposing (InvalidReason(..), Reason(..), format)
 
 {-| The reason a test failed.
 
-@docs Reason, InvalidReason, formatFailure
+@docs Reason, InvalidReason, format
 
 -}
 
@@ -48,13 +48,13 @@ verticalBar comparison expected actual =
 
 
 {-| -}
-formatFailure :
+format :
     { description : String
     , given : Maybe String
     , reason : Reason
     }
     -> String
-formatFailure { description, given, reason } =
+format { description, given, reason } =
     case reason of
         Custom ->
             description

--- a/src/Test/Runner/Failure.elm
+++ b/src/Test/Runner/Failure.elm
@@ -48,9 +48,9 @@ type InvalidReason
 verticalBar : String -> String -> String -> String
 verticalBar comparison expected actual =
     [ actual
-    , "╷"
-    , "│ " ++ comparison
     , "╵"
+    , "│ " ++ comparison
+    , "╷"
     , expected
     ]
         |> String.join "\n"

--- a/src/Test/Runner/Failure.elm
+++ b/src/Test/Runner/Failure.elm
@@ -10,7 +10,7 @@ module Test.Runner.Failure exposing (InvalidReason(..), Reason(..), format)
 {-| -}
 type Reason
     = Custom
-    | Equals String String
+    | Equality String String
     | Comparison String String
       -- Expected, actual, (index of problem, expected element, actual element)
     | ListDiff String String ( Int, String, String )
@@ -59,7 +59,7 @@ format { description, given, reason } =
         Custom ->
             description
 
-        Equals e a ->
+        Equality e a ->
             verticalBar description e a
 
         Comparison e a ->

--- a/src/Test/Runner/Reason.elm
+++ b/src/Test/Runner/Reason.elm
@@ -1,7 +1,39 @@
-module Test.Message exposing (failureMessage)
+module Test.Runner.Reason exposing (InvalidReason(..), Reason(..), formatFailure)
 
-import String
-import Test.Expectation exposing (InvalidReason(..), Reason(..))
+{-| The reason a test failed.
+
+@docs Reason, InvalidReason, formatFailure
+
+-}
+
+
+{-| -}
+type Reason
+    = Custom
+    | Equals String String
+    | Comparison String String
+      -- Expected, actual, (index of problem, expected element, actual element)
+    | ListDiff String String ( Int, String, String )
+      {- I don't think we need to show the diff twice with + and - reversed. Just show it after the main vertical bar.
+         "Extra" and "missing" are relative to the actual value.
+      -}
+    | CollectionDiff
+        { expected : String
+        , actual : String
+        , extra : List String
+        , missing : List String
+        }
+    | TODO
+    | Invalid InvalidReason
+
+
+{-| -}
+type InvalidReason
+    = EmptyList
+    | NonpositiveFuzzCount
+    | InvalidFuzzer
+    | BadDescription
+    | DuplicatedName
 
 
 verticalBar : String -> String -> String -> String
@@ -15,8 +47,14 @@ verticalBar comparison expected actual =
         |> String.join "\n"
 
 
-failureMessage : { given : Maybe String, description : String, reason : Reason } -> String
-failureMessage { given, description, reason } =
+{-| -}
+formatFailure :
+    { description : String
+    , given : Maybe String
+    , reason : Reason
+    }
+    -> String
+formatFailure { description, given, reason } =
     case reason of
         Custom ->
             description

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -4,10 +4,10 @@ import Expect
 import Fuzz exposing (Fuzzer)
 import Random.Pcg as Random
 import Shrink
-import String
 import Test exposing (Test)
 import Test.Expectation exposing (Expectation(..))
 import Test.Internal as Internal
+import Test.Runner.Failure exposing (Reason(..))
 
 
 expectPass : a -> Expectation
@@ -39,7 +39,7 @@ succeeded expectation =
 
 
 passesToFails :
-    ({ reason : Test.Expectation.Reason
+    ({ reason : Reason
      , description : String
      , given : Maybe String
      }
@@ -60,7 +60,7 @@ passesToFails f expectations =
 
 
 passToFail :
-    ({ reason : Test.Expectation.Reason
+    ({ reason : Reason
      , description : String
      , given : Maybe String
      }
@@ -77,7 +77,7 @@ passToFail f expectation =
             f record
 
 
-expectFailureHelper : ({ description : String, given : Maybe String, reason : Test.Expectation.Reason } -> Maybe String) -> Test -> Test
+expectFailureHelper : ({ description : String, given : Maybe String, reason : Reason } -> Maybe String) -> Test -> Test
 expectFailureHelper f test =
     case test of
         Internal.UnitTest runTest ->
@@ -143,7 +143,7 @@ same a b =
             Test.Expectation.Pass
 
         ( a, b ) ->
-            Test.Expectation.fail { description = "expected both arguments to fail, or both to succeed", reason = Test.Expectation.Equals (toString a) (toString b) }
+            Test.Expectation.fail { description = "expected both arguments to fail, or both to succeed", reason = Equals (toString a) (toString b) }
 
 
 different : Expectation -> Expectation -> Expectation
@@ -156,4 +156,4 @@ different a b =
             Test.Expectation.Pass
 
         ( a, b ) ->
-            Test.Expectation.fail { description = "expected one argument to fail", reason = Test.Expectation.Equals (toString a) (toString b) }
+            Test.Expectation.fail { description = "expected one argument to fail", reason = Equals (toString a) (toString b) }

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -143,7 +143,7 @@ same a b =
             Test.Expectation.Pass
 
         ( a, b ) ->
-            Test.Expectation.fail { description = "expected both arguments to fail, or both to succeed", reason = Equals (toString a) (toString b) }
+            Test.Expectation.fail { description = "expected both arguments to fail, or both to succeed", reason = Equality (toString a) (toString b) }
 
 
 different : Expectation -> Expectation -> Expectation
@@ -156,4 +156,4 @@ different a b =
             Test.Expectation.Pass
 
         ( a, b ) ->
-            Test.Expectation.fail { description = "expected one argument to fail", reason = Equals (toString a) (toString b) }
+            Test.Expectation.fail { description = "expected one argument to fail", reason = Equality (toString a) (toString b) }

--- a/tests/Runner/String.elm
+++ b/tests/Runner/String.elm
@@ -13,6 +13,7 @@ Note that this always uses an initial seed of 902101337, since it can't do effec
 
 import Expect exposing (Expectation)
 import Random.Pcg as Random
+import Runner.String.Format
 import Test exposing (Test)
 import Test.Runner exposing (Runner, SeededRunners(..))
 
@@ -52,12 +53,15 @@ toOutputHelp labels runner summary =
 
 fromExpectation : Expectation -> Summary -> Summary
 fromExpectation expectation summary =
-    case Test.Runner.getFailure expectation of
+    case Test.Runner.getFailureReason expectation of
         Nothing ->
             { summary | passed = summary.passed + 1 }
 
-        Just { given, message } ->
+        Just { given, description, reason } ->
             let
+                message =
+                    Runner.String.Format.format description reason
+
                 prefix =
                     case given of
                         Nothing ->

--- a/tests/Runner/String/Format.elm
+++ b/tests/Runner/String/Format.elm
@@ -82,11 +82,15 @@ listDiffToString :
 listDiffToString index description { expected, actual } originals =
     case ( expected, actual ) of
         ( [], [] ) ->
-            -- This should never happen! Recurse into oblivion.
-            listDiffToString (index + 1)
-                description
-                { expected = [], actual = [] }
-                originals
+            [ "Two lists were unequal previously, yet ended up equal later."
+            , "This should never happen!"
+            , "Please report this bug to https://github.com/elm-community/elm-test/issues - and include these lists: "
+            , "\n"
+            , toString originals.originalExpected
+            , "\n"
+            , toString originals.originalActual
+            ]
+                |> String.join ""
 
         ( first :: _, [] ) ->
             verticalBar (description ++ " was shorter than")

--- a/tests/Runner/String/Format.elm
+++ b/tests/Runner/String/Format.elm
@@ -1,0 +1,165 @@
+module Runner.String.Format exposing (format)
+
+import Diff exposing (Change(..))
+import Test.Runner.Failure exposing (InvalidReason(BadDescription), Reason(..))
+
+
+format : String -> Reason -> String
+format description reason =
+    case reason of
+        Custom ->
+            description
+
+        Equality expected actual ->
+            equalityToString { operation = description, expected = expected, actual = actual }
+
+        Comparison first second ->
+            verticalBar description first second
+
+        TODO ->
+            description
+
+        Invalid BadDescription ->
+            if description == "" then
+                "The empty string is not a valid test description."
+            else
+                "This is an invalid test description: " ++ description
+
+        Invalid _ ->
+            description
+
+        ListDiff expected actual ->
+            listDiffToString 0
+                description
+                { expected = expected
+                , actual = actual
+                }
+                { originalExpected = expected
+                , originalActual = actual
+                }
+
+        CollectionDiff { expected, actual, extra, missing } ->
+            let
+                extraStr =
+                    if List.isEmpty extra then
+                        ""
+                    else
+                        "\nThese keys are extra: "
+                            ++ (extra |> String.join ", " |> (\d -> "[ " ++ d ++ " ]"))
+
+                missingStr =
+                    if List.isEmpty missing then
+                        ""
+                    else
+                        "\nThese keys are missing: "
+                            ++ (missing |> String.join ", " |> (\d -> "[ " ++ d ++ " ]"))
+            in
+            String.join ""
+                [ verticalBar description expected actual
+                , "\n"
+                , extraStr
+                , missingStr
+                ]
+
+
+verticalBar : String -> String -> String -> String
+verticalBar comparison expected actual =
+    [ actual
+    , "╵"
+    , "│ " ++ comparison
+    , "╷"
+    , expected
+    ]
+        |> String.join "\n"
+
+
+listDiffToString :
+    Int
+    -> String
+    -> { expected : List String, actual : List String }
+    -> { originalExpected : List String, originalActual : List String }
+    -> String
+listDiffToString index description { expected, actual } originals =
+    case ( expected, actual ) of
+        ( [], [] ) ->
+            -- This should never happen! Recurse into oblivion.
+            listDiffToString (index + 1)
+                description
+                { expected = [], actual = [] }
+                originals
+
+        ( first :: _, [] ) ->
+            verticalBar (description ++ " was shorter than")
+                (toString originals.originalExpected)
+                (toString originals.originalActual)
+
+        ( [], first :: _ ) ->
+            verticalBar (description ++ " was longer than")
+                (toString originals.originalExpected)
+                (toString originals.originalActual)
+
+        ( firstExpected :: restExpected, firstActual :: restActual ) ->
+            if firstExpected == firstActual then
+                -- They're still the same so far; keep going.
+                listDiffToString (index + 1)
+                    description
+                    { expected = restExpected
+                    , actual = restActual
+                    }
+                    originals
+            else
+                -- We found elements that differ; fail!
+                String.join ""
+                    [ verticalBar description
+                        (toString originals.originalExpected)
+                        (toString originals.originalActual)
+                    , "\n\nThe first diff is at index "
+                    , toString index
+                    , ": it was `"
+                    , firstActual
+                    , "`, but `"
+                    , firstExpected
+                    , "` was expected."
+                    ]
+
+
+equalityToString : { operation : String, expected : String, actual : String } -> String
+equalityToString { operation, expected, actual } =
+    let
+        formattedExpected =
+            Diff.diff (String.toList expected) (String.toList actual)
+                |> List.concatMap formatExpectedChange
+                |> String.join ""
+
+        formattedActual =
+            Diff.diff (String.toList actual) (String.toList expected)
+                |> List.concatMap formatActualChange
+                |> String.join ""
+    in
+    verticalBar operation formattedExpected formattedActual
+
+
+formatExpectedChange : Change Char -> List String
+formatExpectedChange diff =
+    case diff of
+        Added char ->
+            []
+
+        Removed char ->
+            [ "\x1B[43m", String.fromChar char, "\x1B[49m" ]
+
+        NoChange char ->
+            [ String.fromChar char ]
+
+
+formatActualChange : Change Char -> List String
+formatActualChange diff =
+    case diff of
+        Added char ->
+            []
+
+        Removed char ->
+            [ "\x1B[43m", String.fromChar char, "\x1B[49m" ]
+
+        NoChange char ->
+            [ String.fromChar char ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,6 +1,5 @@
 module Tests exposing (all)
 
-import Dict
 import Expect exposing (FloatingPointTolerance(Absolute, AbsoluteOrRelative, Relative))
 import FloatWithinTests exposing (floatWithinTests)
 import Fuzz exposing (..)
@@ -8,7 +7,6 @@ import FuzzerTests exposing (fuzzerTests)
 import Helpers exposing (..)
 import Random.Pcg as Random
 import RunnerTests
-import Set
 import Shrink
 import Test exposing (..)
 import Test.Expectation exposing (Expectation(..))

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -13,6 +13,7 @@ import Shrink
 import Test exposing (..)
 import Test.Expectation exposing (Expectation(..))
 import Test.Runner
+import Test.Runner.Failure exposing (Reason(..))
 
 
 all : Test
@@ -121,7 +122,7 @@ testTests =
                     Expect.fail "reason" |> Test.Runner.isTodo |> Expect.false "was true"
             , test "Failures with TODO reason are TODO" <|
                 \_ ->
-                    Test.Expectation.fail { description = "", reason = Test.Expectation.TODO }
+                    Test.Expectation.fail { description = "", reason = TODO }
                         |> Test.Runner.isTodo
                         |> Expect.true "was false"
             ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,6 +12,7 @@
         "eeue56/elm-lazy-list": "1.0.0 <= v < 2.0.0",
         "eeue56/elm-shrink": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "jinjor/elm-diff": "1.0.0 <= v < 2.0.0",
         "eeue56/elm-lazy": "1.0.0 <= v < 2.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
     },


### PR DESCRIPTION
I'd like to implement a version of https://github.com/rtfeldman/node-test-runner/pull/80 that has semantic knowledge of what's on both sides of the `Expect.equal`. Exposing `Reason` directly will facilitate this.

@mgold I know we talked about this awhile ago, but held off at the time. Since we're looking at a 5.0.0 release anyway, I think this is a good time to expose these - while it can still be a MINOR version bump.

It's a big diff because it required reshuffling internals to avoid cyclic dependencies, but here's the API diff:

```diff
------ Added modules - MINOR ------

    Test.Runner.Failure

------ Changes to module Test.Runner - MINOR ------

    Added:
        getFailureReason : Expect.Expectation -> Maybe.Maybe { given : Maybe.Maybe String,
                                                               description : String,
                                                               reason : Test.Runner.Failure.Reason
                                                             }
```

`Test.Runner.Failure.Reason` (which had to be in a separate module from `Test.Runner` to avoid a cyclic dependency) is now exposed, and `Test.Runner.getFailureReason` works just like `Test.Runner.getFailure` except it exposes the `reason : Reason` directly instead of just a `message : String` that has already been formatted.

I also deprecated `Test.Runner.getFailure` (but did not delete it yet), so we can take that out in the next MAJOR release.

Thoughts?