### PR TITLE
Make Fuzz.string generate unicode strings

### DIFF
--- a/src/Util.elm
+++ b/src/Util.elm
@@ -30,3 +30,58 @@ lengthString : Generator Char -> Int -> Generator String
 lengthString charGenerator stringLength =
     list stringLength charGenerator
         |> map String.fromList
+
+
+{-| Creates a generator from either a single element from a single generator,
+a single one of the generators, a pair of the generators or all of the generators,
+then runs Fuzz.frequency on that subset until we have the desired length list.
+
+**Warning:** Do not pass an empty list or your program will crash! In practice
+this is usually not a problem since you pass a list literal.
+
+-}
+frequencyList : Generator Int -> List ( Float, Generator a ) -> Generator (List a)
+frequencyList lengthGenerator pairs =
+    let
+        weightedPairs =
+            pairs |> List.map (\( a, b ) -> ( a, constant ( a, b ) ))
+
+        randomGenerator : Generator ( Float, Generator a )
+        randomGenerator =
+            weightedPairs |> frequency
+
+        generator : Generator (Generator a)
+        generator =
+            sample
+                [ -- single repeated element for a single generator
+                  pairs
+                    |> frequency
+                    |> map constant
+
+                -- single generator
+                , pairs
+                    |> frequency
+                    |> constant
+
+                -- pair
+                , map2
+                    (\a b -> frequency [ a, b ])
+                    randomGenerator
+                    randomGenerator
+
+                -- all
+                , frequency pairs
+                    |> constant
+                ]
+                |> andThen
+                    (\gen ->
+                        case gen of
+                            Nothing ->
+                                Debug.crash "frequencyList is broken; list literal is empty"
+
+                            Just gen ->
+                                gen
+                    )
+    in
+    map2 (,) lengthGenerator generator
+        |> andThen (\( len, gen ) -> list len gen)

--- a/tests/FuzzerTests.elm
+++ b/tests/FuzzerTests.elm
@@ -129,6 +129,7 @@ fuzzerTests =
             , shrinkingTests
             , manualFuzzerTests
             ]
+        , unicodeStringFuzzerTests
         ]
 
 
@@ -259,4 +260,38 @@ manualFuzzerTests =
                         , List.head >> Expect.equal (Just "e")
                         , List.reverse >> List.head >> Expect.equal (Maybe.map Tuple.first pair)
                         ]
+        ]
+
+
+unicodeStringFuzzerTests : Test
+unicodeStringFuzzerTests =
+    describe "unicode string fuzzer"
+        [ expectToFail <|
+            fuzz string "generates ascii" <|
+                \str -> str |> String.contains "E" |> Expect.true "Expected to find ascii letter E"
+        , expectToFail <|
+            fuzz string "generates whitespace" <|
+                \str -> str |> String.contains "\t" |> Expect.true "Expected to find a tab character"
+        , expectToFail <|
+            fuzz string "generates combining diacritical marks" <|
+                \str -> str |> String.contains "̃" |> Expect.true "Expected to find the combining diactricial mark character tilde"
+        , expectToFail <|
+            fuzz string "generates emoji" <|
+                \str -> str |> String.contains "🔥" |> Expect.true "Expected to find 🔥 emoji"
+        , expectToFail <|
+            fuzz string "generates long strings with a single character" <|
+                \str ->
+                    let
+                        countSequentialUniquesAtStart s =
+                            case s of
+                                a :: b :: cs ->
+                                    if a == b then
+                                        1 + countSequentialUniquesAtStart (b :: cs)
+                                    else
+                                        0
+
+                                _ ->
+                                    0
+                    in
+                    str |> String.toList |> countSequentialUniquesAtStart |> (\x -> x < 7) |> Expect.true "expected a string with 7-length duplicates"
         ]


### PR DESCRIPTION
This implements #201. It also replaces the implementation for #198 #200 (generate whitespace-only strings). 

The main difference is that I changed the way we generate strings to make use of equivalence classes:
1. Choose how many classes of characters to use: 
      - single repeated character from a single character class
      - single character class
      - two classes 
      - all classes
2. Pick which character class(es) to use, according to the provided frequency
3. Generate strings of random length according to the previous selections. 

The character classes are:
- ASCII: same as before, characters in the range `[32, 126]` (inclusive)
- Whitespace: same as before, `space, \t, \n`
- Emoji: `🌈, ❤, 🔥`
- Combining diacritical marks: `~^¨`, or rather `̃, ̂, ̈,` (without the commas)

I chose these characters since I think they give people who write websites in English for English users a simple reason to support all of unicode, which helps a lot of people. Bilinguals, people whose names use non-ascii characters, and anyone who wants to use Emoji benefits from this. The characters are all familiar to English speakers, and they cover the most important classes in unicode. Emoji require two utf-16 code units, as does most (all?) Asian characters. Combining diacritical mark support covers all of extended Latin, i.e. all of Europe. 

The only large character class remaining is inline right-to-left text, but I've left that one out because I have no idea what properties you'd test in such a script that aren't relevant to the rest of unicode. Arabic letters change shape depending on where in a sentance they're used, the byte order doesn't match the order the characters are presented on screen, and it becomes possible to generate invalid strings both in the generation and shrinking phases.

---

This change builds on the assumption that "abc" and "xyz" are probably going to trigger the same errors, because they share a lot of properties; a-z, lowercase, sorted, unique characters, same length, substring of the English alphabet.  

I haven't written a custom shrinker for this subset of unicode, maybe I should do that?

I've previously been unsure if we want to release this right away, or wait for core to release a patch. It's not looking like we're getting a patch until the next major version is released, and 0.19 isn't in alpha yet. 
- Some test suites will break if they don't have [the patch from core which fixes `String.toList`](https://github.com/elm-lang/core/commit/8e885c9bd4a7556ee039e2f53bbb3a1555d0243e), and those users will have to use a non-core version of that function until core releases a patch, if they have this bug. The `String.toList >> String.fromList ` identity seems to hold both with and without this bug, so it's not going to affect a lot of users. 
- Or we release it right away, because it's a bug in our users' codebases, and the purpose of testing is to find bugs. 