### PR TITLE
withinCompare handles Relative and negative values

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.2.1",
+    "version": "4.2.0",
     "summary": "Unit and Fuzz testing support with Console/Html/String outputs.",
     "repository": "https://github.com/elm-community/elm-test.git",
     "license": "BSD-3-Clause",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.2.0",
+    "version": "4.2.1",
     "summary": "Unit and Fuzz testing support with Console/Html/String outputs.",
     "repository": "https://github.com/elm-community/elm-test.git",
     "license": "BSD-3-Clause",

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -813,7 +813,7 @@ withinCompare tolerance a b =
             a - absolute tolerance <= b && b <= a + absolute tolerance
 
         withinRelativeTolerance =
-            (a * (1 - relative tolerance) <= b && b <= a * (1 + relative tolerance))
-                || (b * (1 - relative tolerance) <= a && a <= b * (1 + relative tolerance))
+            (a  - (abs (a * relative tolerance)) <= b && b <= a + (abs (a * relative tolerance)))
+                || (b - (abs (b * relative tolerance)) <= a && a <= b + (abs (b * relative tolerance)))
     in
-    (a == b) || withinAbsoluteTolerance || withinRelativeTolerance
+        (a == b) || withinAbsoluteTolerance || withinRelativeTolerance

--- a/tests/FloatWithinTests.elm
+++ b/tests/FloatWithinTests.elm
@@ -35,6 +35,16 @@ floatWithinTests =
                         (radius * pi)
                             |> Expect.within (Relative 0.0001) (radius * 3.14)
             ]
+        , describe "negative use-cases"
+            [   test "negative floats with Absolute" <|
+                    \_ -> -2.9 |> Expect.within (Absolute 0.1) -3
+            ,   test "negative floats with Relative" <|
+                    \_ -> -2.9 |> Expect.within (Relative 0.1) -3
+            ,   test "negative floats with AbsoluteOrRelative" <|
+                    \_ -> -2.9 |> Expect.within (AbsoluteOrRelative 0.1 0.1) -3                
+            ,   test "negative floats with AbsoluteOrRelative passint with Relative" <|
+                    \_ -> -2.9 |> Expect.within (AbsoluteOrRelative 0.001 0.05) -3   
+            ]
         , describe "edge-cases"
             [ fuzz2 float float "self equality" <|
                 \epsilon value ->

--- a/tests/FloatWithinTests.elm
+++ b/tests/FloatWithinTests.elm
@@ -53,10 +53,10 @@ floatWithinTests =
             ,   test "negative actual and positive nominal with Relative" <|
                     \_ -> -0.001 |> Expect.within (Relative 1.1) 3
             ,   expectToFail <|
-                    test "negative nominal should fail as avtual is close, but positive with Absolute" <|
+                    test "negative nominal should fail as actual is close, but positive with Absolute" <|
                         \_ -> 2.9 |> Expect.within (Absolute 0.1) -3
             ,   expectToFail <|    
-                    test "negative nominal should fail as avtual is close, but positive with Relative" <|
+                    test "negative nominal should fail as actual is close, but positive with Relative" <|
                         \_ -> 2.9 |> Expect.within (Relative 0.1) -3
             ]
         , describe "edge-cases"

--- a/tests/FloatWithinTests.elm
+++ b/tests/FloatWithinTests.elm
@@ -35,15 +35,29 @@ floatWithinTests =
                         (radius * pi)
                             |> Expect.within (Relative 0.0001) (radius * 3.14)
             ]
-        , describe "negative use-cases"
-            [   test "negative floats with Absolute" <|
+        , describe "use-cases with negative nominal and/or actual values"
+            [   test "negative nominal and actual with Absolute" <|
                     \_ -> -2.9 |> Expect.within (Absolute 0.1) -3
-            ,   test "negative floats with Relative" <|
+            ,   test "negative nominal and actual with Relative" <|
                     \_ -> -2.9 |> Expect.within (Relative 0.1) -3
-            ,   test "negative floats with AbsoluteOrRelative and pass on Absolute" <|
+            ,   test "negative nominal and actual with AbsoluteOrRelative and pass on Absolute" <|
                     \_ -> -2.9 |> Expect.within (AbsoluteOrRelative 0.1 0.0001) -3                
-            ,   test "negative floats with AbsoluteOrRelative and pass on Relative" <|
-                    \_ -> -2.9 |> Expect.within (AbsoluteOrRelative 0.001 0.05) -3   
+            ,   test "negative nominal and actual with AbsoluteOrRelative and pass on Relative" <|
+                    \_ -> -2.9 |> Expect.within (AbsoluteOrRelative 0.001 0.05) -3
+            ,   test "negative nominal and positive actual with Absolute" <|
+                    \_ -> 0.001 |> Expect.within (Absolute 3.3) -3
+            ,   test "negative nominal and positive actual with Relative" <|
+                    \_ -> 0.001 |> Expect.within (Relative 1.1) -3
+            ,   test "negative actual and positive nominal with Absolute" <|
+                    \_ -> -0.001 |> Expect.within (Absolute 3.3) 3
+            ,   test "negative actual and positive nominal with Relative" <|
+                    \_ -> -0.001 |> Expect.within (Relative 1.1) 3
+            ,   expectToFail <|
+                    test "negative nominal should fail as avtual is close, but positive with Absolute" <|
+                        \_ -> 2.9 |> Expect.within (Absolute 0.1) -3
+            ,   expectToFail <|    
+                    test "negative nominal should fail as avtual is close, but positive with Relative" <|
+                        \_ -> 2.9 |> Expect.within (Relative 0.1) -3
             ]
         , describe "edge-cases"
             [ fuzz2 float float "self equality" <|

--- a/tests/FloatWithinTests.elm
+++ b/tests/FloatWithinTests.elm
@@ -40,9 +40,9 @@ floatWithinTests =
                     \_ -> -2.9 |> Expect.within (Absolute 0.1) -3
             ,   test "negative floats with Relative" <|
                     \_ -> -2.9 |> Expect.within (Relative 0.1) -3
-            ,   test "negative floats with AbsoluteOrRelative" <|
-                    \_ -> -2.9 |> Expect.within (AbsoluteOrRelative 0.1 0.1) -3                
-            ,   test "negative floats with AbsoluteOrRelative passint with Relative" <|
+            ,   test "negative floats with AbsoluteOrRelative and pass on Absolute" <|
+                    \_ -> -2.9 |> Expect.within (AbsoluteOrRelative 0.1 0.0001) -3                
+            ,   test "negative floats with AbsoluteOrRelative and pass on Relative" <|
                     \_ -> -2.9 |> Expect.within (AbsoluteOrRelative 0.001 0.05) -3   
             ]
         , describe "edge-cases"


### PR DESCRIPTION
In response to issue #211(Expect.within for Relative does not work for negative values).
- no changes needed to Absolute tolerance handling.
- solution was to adapt Relative tolerance handling to work like Absolute
-- calculate actual tolerance and then subtract it on the low end and add it to the high end