### PR TITLE
Corrects shrink package name in `Fuzz.custom` docs

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -63,7 +63,7 @@ type alias Fuzzer a =
 {-| Build a custom `Fuzzer a` by providing a `Generator a` and a `Shrinker a`.
 Generators are defined in [`mgold/elm-random-pcg`](http://package.elm-lang.org/packages/mgold/elm-random-pcg/latest),
 which is not core's Random module but has a compatible interface. Shrinkers are
-defined in [`elm-community/shrink`](http://package.elm-lang.org/packages/elm-community/shrink/latest/).
+defined in [`eeue56/elm-shrink`](http://package.elm-lang.org/packages/eeue56/elm-shrink/latest/).
 
 Here is an example for a record:
 


### PR DESCRIPTION
The current docs for `Fuzz.custom` point to the wrong shrink package -- looks like `elm-test` changed from `elm-community/shrink` to `eeue56/elm-shrink` a few months back but but this bit of documentation wasn't corrected. This PR just corrects the docs to point to the right package.