### PR TITLE
Remove Expect.true and Expect.false

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -11,14 +11,12 @@ module Expect
         , equalSets
         , err
         , fail
-        , false
         , greaterThan
         , lessThan
         , notEqual
         , notWithin
         , onFail
         , pass
-        , true
         , within
         )
 
@@ -33,8 +31,6 @@ module Expect
   - [`atMost`](#atMost) `(arg2 <= arg1)`
   - [`greaterThan`](#greaterThan) `(arg2 > arg1)`
   - [`atLeast`](#atLeast) `(arg2 >= arg1)`
-  - [`true`](#true) `(arg == True)`
-  - [`false`](#false) `(arg == False)`
   - [Floating Point Comparisons](#floating-point-comparisons)
 
 
@@ -54,11 +50,6 @@ These functions allow you to compare `Float` values up to a specified rounding e
 or both. For an in-depth look, see our [Guide to Floating Point Comparison](#guide-to-floating-point-comparison).
 
 @docs FloatingPointTolerance, within, notWithin
-
-
-## Booleans
-
-@docs true, false
 
 
 ## Collections
@@ -368,64 +359,6 @@ notWithin tolerance a b =
             (\a b -> not <| withinCompare tolerance a b)
             a
             b
-
-
-{-| Passes if the argument is 'True', and otherwise fails with the given message.
-
-    Expect.true "Expected the list to be empty." (List.isEmpty [])
-
-    -- Passes because (List.isEmpty []) is True
-
-Failures resemble code written in pipeline style, so you can tell
-which argument is which:
-
-    -- Fails because List.isEmpty returns False, but we expect True.
-    List.isEmpty [ 42 ]
-        |> Expect.true "Expected the list to be empty."
-
-    {-
-
-    Expected the list to be empty.
-
-    -}
-
--}
-true : String -> Bool -> Expectation
-true message bool =
-    if bool then
-        pass
-
-    else
-        fail message
-
-
-{-| Passes if the argument is 'False', and otherwise fails with the given message.
-
-    Expect.false "Expected the list not to be empty." (List.isEmpty [ 42 ])
-
-    -- Passes because (List.isEmpty [ 42 ]) is False
-
-Failures resemble code written in pipeline style, so you can tell
-which argument is which:
-
-    -- Fails because (List.isEmpty []) is True
-    List.isEmpty []
-        |> Expect.false "Expected the list not to be empty."
-
-    {-
-
-    Expected the list not to be empty.
-
-    -}
-
--}
-false : String -> Bool -> Expectation
-false message bool =
-    if bool then
-        fail message
-
-    else
-        pass
 
 
 {-| Passes if the

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -394,6 +394,7 @@ true : String -> Bool -> Expectation
 true message bool =
     if bool then
         pass
+
     else
         fail message
 
@@ -422,6 +423,7 @@ false : String -> Bool -> Expectation
 false message bool =
     if bool then
         fail message
+
     else
         pass
 
@@ -498,6 +500,7 @@ equalLists : List a -> List a -> Expectation
 equalLists expected actual =
     if expected == actual then
         pass
+
     else
         { description = "Expect.equalLists"
         , reason = ListDiff (List.map toString expected) (List.map toString actual)
@@ -536,11 +539,13 @@ equalDicts : Dict comparable a -> Dict comparable a -> Expectation
 equalDicts expected actual =
     if Dict.toList expected == Dict.toList actual then
         pass
+
     else
         let
             differ dict k v diffs =
                 if Dict.get k dict == Just v then
                     diffs
+
                 else
                     ( k, v ) :: diffs
 
@@ -584,6 +589,7 @@ equalSets : Set comparable -> Set comparable -> Expectation
 equalSets expected actual =
     if Set.toList expected == Set.toList actual then
         pass
+
     else
         let
             missingKeys =
@@ -696,6 +702,7 @@ all list query =
             { reason = Invalid EmptyList
             , description = "Expect.all was given an empty list. You must make at least one expectation to have a valid test!"
             }
+
     else
         allHelp list query
 
@@ -757,6 +764,7 @@ testWith : (String -> String -> Reason) -> String -> (a -> b -> Bool) -> b -> a 
 testWith makeReason label runTest expected actual =
     if runTest actual expected then
         pass
+
     else
         { description = label
         , reason = makeReason (toString expected) (toString actual)
@@ -798,10 +806,13 @@ nonNegativeToleranceError : FloatingPointTolerance -> String -> Expectation -> E
 nonNegativeToleranceError tolerance name result =
     if absolute tolerance < 0 && relative tolerance < 0 then
         Test.Expectation.fail { description = "Expect." ++ name ++ " was given negative absolute and relative tolerances", reason = Custom }
+
     else if absolute tolerance < 0 then
         Test.Expectation.fail { description = "Expect." ++ name ++ " was given a negative absolute tolerance", reason = Custom }
+
     else if relative tolerance < 0 then
         Test.Expectation.fail { description = "Expect." ++ name ++ " was given a negative relative tolerance", reason = Custom }
+
     else
         result
 
@@ -813,7 +824,7 @@ withinCompare tolerance a b =
             a - absolute tolerance <= b && b <= a + absolute tolerance
 
         withinRelativeTolerance =
-            (a  - (abs (a * relative tolerance)) <= b && b <= a + (abs (a * relative tolerance)))
-                || (b - (abs (b * relative tolerance)) <= a && a <= b + (abs (b * relative tolerance)))
+            (a - abs (a * relative tolerance) <= b && b <= a + abs (a * relative tolerance))
+                || (b - abs (b * relative tolerance) <= a && a <= b + abs (b * relative tolerance))
     in
-        (a == b) || withinAbsoluteTolerance || withinRelativeTolerance
+    (a == b) || withinAbsoluteTolerance || withinRelativeTolerance

--- a/tests/FuzzerTests.elm
+++ b/tests/FuzzerTests.elm
@@ -95,6 +95,7 @@ fuzzerTests =
                             Just ( value, next ) ->
                                 if even value then
                                     testShrinkable next
+
                                 else
                                     Expect.fail <| "Shrunken value does not pass conditional: " ++ toString value
                 in
@@ -170,6 +171,7 @@ shrinkingTests =
                                 a :: b :: more ->
                                     if a > b then
                                         False
+
                                     else
                                         checkPair (b :: more)
 
@@ -200,6 +202,7 @@ manualFuzzerTests =
                                 (\n ->
                                     if failsTest n then
                                         n
+
                                     else
                                         n + 1
                                 )
@@ -217,6 +220,7 @@ manualFuzzerTests =
                             Just ( valN, shrinkN ) ->
                                 if failsTest valN then
                                     unfold (valN :: acc) (Test.Runner.shrink False shrinkN)
+
                                 else
                                     unfold acc (Test.Runner.shrink True shrinkN)
 
@@ -251,6 +255,7 @@ manualFuzzerTests =
                             Just ( valN, shrinkN ) ->
                                 if failsTest valN then
                                     unfold (valN :: acc) (Test.Runner.shrink False shrinkN)
+
                                 else
                                     unfold acc (Test.Runner.shrink True shrinkN)
 
@@ -287,6 +292,7 @@ manualFuzzerTests =
                                 shrink
                                     (if allEven valN then
                                         shrunken
+
                                      else
                                         Just valN
                                     )

--- a/tests/FuzzerTests.elm
+++ b/tests/FuzzerTests.elm
@@ -135,26 +135,33 @@ fuzzerTests =
 
 shrinkingTests : Test
 shrinkingTests =
+    let
+    -- To test shrinking, we have to fail some tests so we can shrink their inputs.
+    -- The best place we found for storing the expected last state(s) of the shrinking procedure is the description field, which is why we have this function here.
+    -- Previously, we (ab)used Expect.true for this, but since that was removed, here we are.
+        expectTrueAndExpectShrinkResultToEqualString label a =
+            Expect.equal True a |> Expect.onFail label
+    in
     testShrinking <|
         describe "tests that fail intentionally to test shrinking"
             [ fuzz2 int int "Every pair of ints has a zero" <|
                 \i j ->
                     (i == 0)
                         || (j == 0)
-                        |> Expect.true "(1,1)"
+                        |> expectTrueAndExpectShrinkResultToEqualString "(1,1)"
             , fuzz3 int int int "Every triple of ints has a zero" <|
                 \i j k ->
                     (i == 0)
                         || (j == 0)
                         || (k == 0)
-                        |> Expect.true "(1,1,1)"
+                        |> expectTrueAndExpectShrinkResultToEqualString "(1,1,1)"
             , fuzz4 int int int int "Every 4-tuple of ints has a zero" <|
                 \i j k l ->
                     (i == 0)
                         || (j == 0)
                         || (k == 0)
                         || (l == 0)
-                        |> Expect.true "(1,1,1,1)"
+                        |> expectTrueAndExpectShrinkResultToEqualString "(1,1,1,1)"
             , fuzz5 int int int int int "Every 5-tuple of ints has a zero" <|
                 \i j k l m ->
                     (i == 0)
@@ -162,7 +169,7 @@ shrinkingTests =
                         || (k == 0)
                         || (l == 0)
                         || (m == 0)
-                        |> Expect.true "(1,1,1,1,1)"
+                        |> expectTrueAndExpectShrinkResultToEqualString "(1,1,1,1,1)"
             , fuzz (list int) "All lists are sorted" <|
                 \aList ->
                     let
@@ -178,10 +185,10 @@ shrinkingTests =
                                 _ ->
                                     True
                     in
-                    checkPair aList |> Expect.true "[1,0]|[0,-1]"
+                    checkPair aList |> expectTrueAndExpectShrinkResultToEqualString "[1,0]|[0,-1]"
             , fuzz (intRange 1 8 |> andThen (\i -> intRange 0 (2 ^ i))) "Fuzz.andThen shrinks a number" <|
                 \i ->
-                    i <= 2 |> Expect.true "3"
+                    i <= 2 |> expectTrueAndExpectShrinkResultToEqualString "3"
             ]
 
 
@@ -229,7 +236,7 @@ manualFuzzerTests =
                 in
                 unfold [] pair
                     |> Expect.all
-                        [ List.all failsTest >> Expect.true "Not all elements were even"
+                        [ List.all failsTest >> Expect.equal True >> Expect.onFail "Not all elements were even"
                         , List.head
                             >> Maybe.map (Expect.all [ Expect.lessThan 5, Expect.atLeast 0 ])
                             >> Maybe.withDefault (Expect.fail "Did not cause failure")
@@ -264,7 +271,7 @@ manualFuzzerTests =
                 in
                 unfold [] pair
                     |> Expect.all
-                        [ List.all failsTest >> Expect.true "Not all contained the letter e"
+                        [ List.all failsTest >> Expect.equal True >> Expect.onFail "Not all contained the letter e"
                         , List.head >> Expect.equal (Just "e")
                         , List.reverse >> List.head >> Expect.equal (Maybe.map Tuple.first pair)
                         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -114,15 +114,15 @@ testTests =
         , describe "Test.todo"
             [ expectToFail <| todo "a TODO test fails"
             , test "Passes are not TODO"
-                (\_ -> Expect.pass |> Test.Runner.isTodo |> Expect.false "was true")
+                (\_ -> Expect.pass |> Test.Runner.isTodo |> Expect.equal False)
             , test "Simple failures are not TODO" <|
                 \_ ->
-                    Expect.fail "reason" |> Test.Runner.isTodo |> Expect.false "was true"
+                    Expect.fail "reason" |> Test.Runner.isTodo |> Expect.equal False
             , test "Failures with TODO reason are TODO" <|
                 \_ ->
                     Test.Expectation.fail { description = "", reason = TODO }
                         |> Test.Runner.isTodo
-                        |> Expect.true "was false"
+                        |> Expect.equal True
             ]
         , identicalNamesAreRejectedTests
         ]


### PR DESCRIPTION
This implements #240.

`Expect.true` can be implemented as `Expect.equal True >> Expect.onFail` if you did have a useful description, and as `Expect.equal True` if you didn't.